### PR TITLE
Support new release versioning

### DIFF
--- a/dvm-helper/dockerversion/dockerversion.go
+++ b/dvm-helper/dockerversion/dockerversion.go
@@ -29,6 +29,23 @@ func Parse(value string) Version {
 	return New(semver)
 }
 
+func (version Version) IsPrerelease() bool {
+	if version.SemVer == nil {
+		return false
+	}
+
+	tag := version.SemVer.Prerelease()
+
+	preTags := []string{"rc", "alpha", "beta"}
+	for i := 0; i < len(preTags); i++ {
+		if strings.Contains(tag, preTags[i]) {
+			return true
+		}
+	}
+
+	return false
+}
+
 func (version Version) IsEmpty() bool {
 	return version.Alias == "" && version.SemVer == nil
 }

--- a/dvm-helper/dockerversion/dockerversion.go
+++ b/dvm-helper/dockerversion/dockerversion.go
@@ -1,24 +1,27 @@
 package dockerversion
 
-import "fmt"
-import "sort"
-import "strings"
-import "github.com/blang/semver"
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/Masterminds/semver"
+)
 
 const SystemAlias = "system"
 const ExperimentalAlias = "experimental"
 
 type Version struct {
-	SemVer semver.Version
+	SemVer *semver.Version
 	Alias  string
 }
 
-func New(semver semver.Version) Version {
+func New(semver *semver.Version) Version {
 	return Version{SemVer: semver}
 }
 
 func Parse(value string) Version {
-	semver, err := semver.Parse(value)
+	semver, err := semver.NewVersion(value)
 	if err != nil {
 		return Version{Alias: value}
 	}
@@ -26,16 +29,8 @@ func Parse(value string) Version {
 	return New(semver)
 }
 
-func (version Version) HasAlias() bool {
-	return version.Alias != ""
-}
-
-func (version Version) HasSemVer() bool {
-	return !(version.SemVer.Major == 0 && version.SemVer.Minor == 0 && version.SemVer.Patch == 0)
-}
-
 func (version Version) IsEmpty() bool {
-	return !version.HasAlias() && !version.HasSemVer()
+	return version.Alias == "" && version.SemVer == nil
 }
 
 func (version Version) IsSystem() bool {
@@ -55,13 +50,13 @@ func (version *Version) SetAsExperimental() {
 }
 
 func (version Version) ShouldUseArchivedRelease() bool {
-	cutoff := semver.MustParse("1.11.0")
-	return version.IsExperimental() || version.SemVer.GTE(cutoff)
+	cutoff, _ := semver.NewConstraint(">= 1.11.0")
+	return version.IsExperimental() || cutoff.Check(version.SemVer)
 }
 
 func (version Version) String() string {
-	if version.HasAlias() {
-		if version.HasSemVer() {
+	if version.Alias != "" {
+		if version.SemVer != nil {
 			return fmt.Sprintf("%s (%s)", version.Alias, version.SemVer.String())
 		}
 		return version.Alias
@@ -74,7 +69,11 @@ func (version Version) String() string {
 // 0 == v is equal to o
 // 1 == v is greater than o
 func (v Version) Compare(o Version) int {
-	return v.SemVer.Compare(o.SemVer)
+	if v.SemVer != nil && o.SemVer != nil {
+		return v.SemVer.Compare(o.SemVer)
+	}
+
+	return strings.Compare(v.Alias, o.Alias)
 }
 
 // Equals checks if v is equal to o.
@@ -82,13 +81,8 @@ func (v Version) Equals(o Version) bool {
 	semverMatch := v.Compare(o) == 0
 	// Enables distinguishing between X.Y.Z and system (X.Y.Z)
 	systemMatch := v.IsSystem() == o.IsSystem()
-	aliasmatch := v.HasAlias() && strings.Compare(v.Alias, o.Alias) == 0
+	aliasmatch := v.Alias != "" && v.Alias == o.Alias
 	return (semverMatch && systemMatch) || aliasmatch
-}
-
-// LT checks if v is less than o.
-func (v Version) LT(o Version) bool {
-	return v.Compare(o) == -1
 }
 
 type Versions []Version
@@ -102,7 +96,7 @@ func (s Versions) Swap(i, j int) {
 }
 
 func (s Versions) Less(i, j int) bool {
-	return s[i].LT(s[j])
+	return s[i].Compare(s[j]) == -1
 }
 
 func Sort(versions []Version) {

--- a/dvm-helper/dockerversion/dockerversion_test.go
+++ b/dvm-helper/dockerversion/dockerversion_test.go
@@ -10,3 +10,23 @@ func TestStripLeadingV(t *testing.T) {
 	v := Parse("v1.0.0")
 	assert.Equal(t, "1.0.0", v.String())
 }
+
+func TestIsPrerelease(t *testing.T) {
+	var v Version
+
+	v = Parse("17.3.0-ce-rc1")
+	t.Log(v.SemVer.Prerelease())
+	assert.True(t, v.IsPrerelease(), "%s should be a prerelease", v)
+
+	v = Parse("1.12.4-rc1")
+	assert.True(t, v.IsPrerelease(), "%s should be a prerelease", v)
+
+	v = Parse("1.12.4-beta.1")
+	assert.True(t, v.IsPrerelease(), "%s should be a prerelease", v)
+
+	v = Parse("1.12.4-alpha-2")
+	assert.True(t, v.IsPrerelease(), "%s should be a prerelease", v)
+
+	v = Parse("17.3.0-ce")
+	assert.False(t, v.IsPrerelease(), "%s should NOT be a prerelease", v)
+}

--- a/dvm-helper/dockerversion/dockerversion_test.go
+++ b/dvm-helper/dockerversion/dockerversion_test.go
@@ -1,0 +1,12 @@
+package dockerversion
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStripLeadingV(t *testing.T) {
+	v := Parse("v1.0.0")
+	assert.Equal(t, "1.0.0", v.String())
+}

--- a/dvm-helper/dvm-helper.go
+++ b/dvm-helper/dvm-helper.go
@@ -13,7 +13,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/blang/semver"
+	"github.com/Masterminds/semver"
 	"github.com/codegangsta/cli"
 	dockerclient "github.com/docker/docker/client"
 	"github.com/fatih/color"
@@ -181,7 +181,7 @@ func main() {
 		{
 			Name:    "list-remote",
 			Aliases: []string{"ls-remote"},
-			Usage:   "dvm list-remote [<pattern>]\n\tList available Docker versions.",
+			Usage:   "dvm list-remote [<prefix>]\n\tList available Docker versions.",
 			Action: func(c *cli.Context) error {
 				setGlobalVars(c)
 				listRemote(c.Args().First())
@@ -248,7 +248,7 @@ func detect() {
 	}
 
 	writeDebug("Queried /version and got Version: %s", versionResult.Version)
-	version, err := semver.Parse(versionResult.Version)
+	version, err := semver.NewVersion(versionResult.Version)
 
 	// Docker versions prior to 1.12 don't return a usable client version
 	// Lookup the client version from the API version
@@ -269,17 +269,18 @@ func detect() {
 			die("Unable to detect the proper client version for Docker API version %s", nil, retCodeRuntimeError, versionResult.APIVersion)
 		}
 
-		// Find the highest version that statisfies the client version range
-		clientRange := semver.MustParseRange(clientVersion)
+		// Find the highest version that satisfies the client version range
+		clientRange, _ := semver.NewConstraint(clientVersion)
 		availableVersions := getAvailableVersions("")
 		for i := len(availableVersions) - 1; i >= 0; i-- {
 			v := availableVersions[i]
-			if clientRange(v.SemVer) {
+
+			if clientRange.Check(v.SemVer) {
 				version = v.SemVer
 				break
 			}
 		}
-		if version.Equals(semver.Version{}) {
+		if version == nil {
 			die("Unable to detect the proper client version for Docker client version %s", nil, retCodeRuntimeError, clientVersion)
 		}
 	}
@@ -447,7 +448,7 @@ func use(version dockerversion.Version) {
 		die("The use command requires that a version is specified or the DOCKER_VERSION environment variable is set.", nil, retCodeInvalidOperation)
 	}
 
-	if version.HasAlias() && aliasExists(version.Alias) {
+	if version.Alias != "" && aliasExists(version.Alias) {
 		aliasedVersion, _ := ioutil.ReadFile(getAliasPath(version.Alias))
 		version.SemVer = semver.MustParse(string(aliasedVersion))
 		writeDebug("Using alias: %s -> %s", version.Alias, version.SemVer)
@@ -714,8 +715,8 @@ func getDockerVersion(dockerPath string, includeBuild bool) (dockerversion.Versi
 	return dockerversion.Parse(version), nil
 }
 
-func listRemote(pattern string) {
-	versions := getAvailableVersions(pattern)
+func listRemote(prefix string) {
+	versions := getAvailableVersions(prefix)
 	for _, version := range versions {
 		writeInfo(version.String())
 	}
@@ -775,18 +776,18 @@ func getAvailableVersions(pattern string) []dockerversion.Version {
 		options.Page = response.NextPage
 	}
 
-	versionRegex := regexp.MustCompile(`^v([1-9]+\.\d+\.\d+)$`)
-	patternRegex, err := regexp.Compile(pattern)
-	if err != nil {
-		die("Invalid pattern.", err, retCodeInvalidOperation)
-	}
-
 	var results []dockerversion.Version
 	for _, release := range allReleases {
 		version := *release.Name
-		match := versionRegex.FindStringSubmatch(version)
-		if len(match) > 1 && patternRegex.MatchString(version) {
-			results = append(results, dockerversion.Parse(match[1]))
+		v := dockerversion.Parse(version)
+		if v.SemVer == nil {
+			writeDebug("Ignoring non-semver Docker release: %s", version)
+			continue
+		}
+
+		if strings.HasPrefix(v.SemVer.String(), pattern) {
+
+			results = append(results, v)
 		}
 	}
 
@@ -808,20 +809,20 @@ func isUpgradeAvailable() (bool, string) {
 		return false, ""
 	}
 
-	currentVersion, err := semver.Make(dvmVersion)
+	currentVersion, err := semver.NewVersion(dvmVersion)
 	if err != nil {
 		writeWarning("Unable to parse the current dvm version as a semantic version!")
 		writeWarning("%s", err)
 		return false, ""
 	}
-	latestVersion, err := semver.Make(*release.TagName)
+	latestVersion, err := semver.NewVersion(*release.TagName)
 	if err != nil {
 		writeWarning("Unable to parse the latest dvm version as a semantic version!")
 		writeWarning("%s", err)
 		return false, ""
 	}
 
-	return latestVersion.Compare(currentVersion) > 0, *release.TagName
+	return latestVersion.GreaterThan(currentVersion), *release.TagName
 }
 
 func getVersionsDir() string {

--- a/dvm-helper/dvm-helper.go
+++ b/dvm-helper/dvm-helper.go
@@ -33,6 +33,7 @@ var debug bool
 var silent bool
 var nocheck bool
 var token string
+var includePrereleases bool
 
 // These are set during the build
 var dvmVersion string
@@ -182,8 +183,12 @@ func main() {
 			Name:    "list-remote",
 			Aliases: []string{"ls-remote"},
 			Usage:   "dvm list-remote [<prefix>]\n\tList available Docker versions.",
+			Flags: []cli.Flag{
+				cli.BoolFlag{Name: "pre", Usage: "Include pre-release versions"},
+			},
 			Action: func(c *cli.Context) error {
 				setGlobalVars(c)
+
 				listRemote(c.Args().First())
 				return nil
 			},
@@ -228,6 +233,7 @@ func setGlobalVars(c *cli.Context) {
 
 	silent = c.GlobalBool("silent")
 	mirrorURL = c.String("mirror-url")
+	includePrereleases = c.Bool("pre")
 
 	dvmDir = c.GlobalString("dvm-dir")
 	if dvmDir == "" {
@@ -785,8 +791,11 @@ func getAvailableVersions(pattern string) []dockerversion.Version {
 			continue
 		}
 
-		if strings.HasPrefix(v.SemVer.String(), pattern) {
+		if !includePrereleases && v.IsPrerelease() {
+			continue
+		}
 
+		if strings.HasPrefix(v.SemVer.String(), pattern) {
 			results = append(results, v)
 		}
 	}

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 1f785d0ac14223e0366995b6a5e0716677e141bb81a9c888c7f2e650c49debea
-updated: 2017-02-16T15:37:42.300441023-06:00
+hash: 16053c82a71f9bd509b05a4523df6bc418aed2083e4b8bd97a870bbc003256f8
+updated: 2017-03-07T17:02:32.214383898-06:00
 imports:
 - name: github.com/blang/semver
   version: 4a1e882c79dcf4ec00d2e29fac74b9c8938d5052
@@ -8,33 +8,33 @@ imports:
 - name: github.com/docker/distribution
   version: 4f87c800734ffe0d8931e45679112aea36f8b5ec
   subpackages:
-  - reference
   - digestset
+  - reference
 - name: github.com/docker/docker
   version: 092cba3727bb9b4a2f0e922cd6c0f93ea270e363
   subpackages:
-  - client
   - api/types
+  - api/types/blkiodev
   - api/types/container
   - api/types/events
   - api/types/filters
+  - api/types/mount
   - api/types/network
   - api/types/reference
   - api/types/registry
+  - api/types/strslice
   - api/types/swarm
   - api/types/time
   - api/types/versions
   - api/types/volume
+  - client
   - pkg/tlsconfig
-  - api/types/mount
-  - api/types/blkiodev
-  - api/types/strslice
 - name: github.com/docker/go-connections
   version: 7da10c8c50cad14494ec818dcdfb6506265c0086
   subpackages:
+  - nat
   - sockets
   - tlsconfig
-  - nat
 - name: github.com/docker/go-units
   version: 0dadbb0345b35ec7ef35e228dabb8de89a65bf52
 - name: github.com/fatih/color
@@ -51,6 +51,8 @@ imports:
   version: 53e6ce116135b80d037921a7fdd5138cf32d7a8a
   subpackages:
   - query
+- name: github.com/Masterminds/semver
+  version: 59c29afe1a994eacb71c833025ca7acf874bb1da
 - name: github.com/mattn/go-colorable
   version: 5411d3eea5978e6cdc258b30de592b60df6aba96
 - name: github.com/mattn/go-isatty
@@ -91,16 +93,16 @@ imports:
 - name: google.golang.org/appengine
   version: 2e4a801b39fc199db615bfca7d0b9f8cd9580599
   subpackages:
-  - urlfetch
   - internal
-  - internal/urlfetch
   - internal/base
   - internal/datastore
   - internal/log
   - internal/remote_api
+  - internal/urlfetch
+  - urlfetch
 testImports:
 - name: github.com/davecgh/go-spew
-  version: 04cdfd42973bb9c8589fd6a731800cf222fde1a9
+  version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
   subpackages:
   - spew
 - name: github.com/pmezard/go-difflib

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,6 +1,5 @@
 package: github.com/howtowhale/dvm
 import:
-- package: github.com/blang/semver
 - package: github.com/codegangsta/cli
 - package: github.com/fatih/color
 - package: github.com/pivotal-golang/archiver
@@ -18,3 +17,5 @@ import:
   version: ^1.1.4
   subpackages:
   - assert
+- package: github.com/Masterminds/semver
+  version: ^1.2.2


### PR DESCRIPTION
Fixes #152.

* Handle Docker's new versioning scheme, which uses the version tag to differentiate between editions, e.g `17.3.0-ce`
* Exclude pre-releases by default. 
    
    Previously, we always excluded versions with prerelease tag. Now that Docker uses the tag for non-prerelease versions, we need to be smarter about what to show when. 

    To display prereleases, use the `-pre` flag, e.g. `dvm list-remote -pre 1.13`