### PR TITLE
Support installing prereleases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ validate:
 	-go list ./... | grep -v /vendor/ | xargs -L1 golint --set_exit_status
 
 test: local
-	go test $(GOFILES_NOVENDOR)
+	go test -v $(GOFILES_NOVENDOR)
 	eval "$( ./dvm-helper --bash-completion )"
 	./dvm-helper/dvm-helper --version
 

--- a/dvm-helper/dockerversion/dockerversion.go
+++ b/dvm-helper/dockerversion/dockerversion.go
@@ -67,7 +67,7 @@ func (version *Version) SetAsExperimental() {
 }
 
 func (version Version) ShouldUseArchivedRelease() bool {
-	cutoff, _ := semver.NewConstraint(">= 1.11.0")
+	cutoff, _ := semver.NewConstraint(">= 1.11.0-rc1")
 	return version.IsExperimental() || cutoff.Check(version.SemVer)
 }
 

--- a/dvm-helper/dockerversion/dockerversion_test.go
+++ b/dvm-helper/dockerversion/dockerversion_test.go
@@ -15,7 +15,6 @@ func TestIsPrerelease(t *testing.T) {
 	var v Version
 
 	v = Parse("17.3.0-ce-rc1")
-	t.Log(v.SemVer.Prerelease())
 	assert.True(t, v.IsPrerelease(), "%s should be a prerelease", v)
 
 	v = Parse("1.12.4-rc1")
@@ -29,4 +28,10 @@ func TestIsPrerelease(t *testing.T) {
 
 	v = Parse("17.3.0-ce")
 	assert.False(t, v.IsPrerelease(), "%s should NOT be a prerelease", v)
+}
+
+func TestPrereleasesUseArchivedReleases(t *testing.T) {
+	v := Parse("v1.12.5-rc1")
+
+	assert.True(t, v.ShouldUseArchivedRelease())
 }

--- a/dvm-helper/dvm-helper.go
+++ b/dvm-helper/dvm-helper.go
@@ -734,6 +734,9 @@ func getDockerVersion(dockerPath string, includeBuild bool) (dockerversion.Versi
 func listRemote(prefix string) {
 	versions := getAvailableVersions(prefix)
 	for _, version := range versions {
+		if !includePrereleases && version.IsPrerelease() {
+			continue
+		}
 		writeInfo(version.String())
 	}
 }
@@ -798,10 +801,6 @@ func getAvailableVersions(pattern string) []dockerversion.Version {
 		v := dockerversion.Parse(version)
 		if v.SemVer == nil {
 			writeDebug("Ignoring non-semver Docker release: %s", version)
-			continue
-		}
-
-		if !includePrereleases && v.IsPrerelease() {
 			continue
 		}
 

--- a/dvm-helper/dvm-helper.go
+++ b/dvm-helper/dvm-helper.go
@@ -32,7 +32,7 @@ var githubUrlOverride string
 var debug bool
 var silent bool
 var nocheck bool
-var useAfterInstall bool = true
+var useAfterInstall bool
 var token string
 var includePrereleases bool
 
@@ -49,6 +49,11 @@ const (
 )
 
 func main() {
+	app := makeCliApp()
+	app.Run(os.Args)
+}
+
+func makeCliApp() *cli.App {
 	app := cli.NewApp()
 	app.Name = "Docker Version Manager"
 	app.Usage = "Manage multiple versions of the Docker client"
@@ -222,10 +227,12 @@ func main() {
 		})
 	}
 
-	app.Run(os.Args)
+	return app
 }
 
 func setGlobalVars(c *cli.Context) {
+	useAfterInstall = true
+
 	debug = c.GlobalBool("debug")
 	nocheck = c.Bool("nocheck")
 	token = c.GlobalString("github-token")

--- a/dvm-helper/dvm-helper.go
+++ b/dvm-helper/dvm-helper.go
@@ -410,6 +410,10 @@ func buildDownloadURL(version dockerversion.Version) string {
 			writeDebug("Downloading from experimental builds mirror")
 			mirrorURL = "https://experimental.docker.com/builds"
 		}
+		if version.IsPrerelease() {
+			writeDebug("Downloading from prerelease builds mirror")
+			mirrorURL = "https://test.docker.com/builds"
+		}
 	}
 
 	// New Docker versions are released in a zip file, vs. the old way of releasing the client binary only

--- a/dvm-helper/dvm-helper_test.go
+++ b/dvm-helper/dvm-helper_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/fatih/color"
+	"github.com/howtowhale/dvm/dvm-helper/dockerversion"
 	"github.com/ryanuber/go-glob"
 	"github.com/stretchr/testify/assert"
 )
@@ -128,6 +129,15 @@ func TestListWithPrereleases(t *testing.T) {
 	assert.NotEmpty(t, output, "Should have captured stdout")
 	assert.Contains(t, output, "1.12.5-rc1", "Should have listed a prerelease version")
 
+}
+
+func TestInstallPrereleases(t *testing.T) {
+	_, github := createMockDVM(nil)
+	defer github.Close()
+
+	debug = true
+
+	install(dockerversion.Parse("v1.12.5-rc1"))
 }
 
 func loadTestData(src string) string {


### PR DESCRIPTION
Now that `dvm list-remote --pre` exists, we should allow installing a prerelease.