### PR TITLE
Remove unnecessary checks that a version exists

### DIFF
--- a/dvm-helper/dvm-helper.go
+++ b/dvm-helper/dvm-helper.go
@@ -32,6 +32,7 @@ var githubUrlOverride string
 var debug bool
 var silent bool
 var nocheck bool
+var useAfterInstall bool = true
 var token string
 var includePrereleases bool
 
@@ -294,6 +295,8 @@ func detect() {
 
 	os.Setenv(versionEnvVar, version.String())
 	writeEnvironmentVariableScript(versionEnvVar)
+
+	nocheck = true
 	use(dockerversion.New(version))
 }
 
@@ -378,6 +381,7 @@ func install(version dockerversion.Version) {
 
 	if _, err := os.Stat(versionDir); err == nil {
 		writeWarning("%s is already installed", version)
+		nocheck = true
 		use(version)
 		return
 	}
@@ -385,7 +389,11 @@ func install(version dockerversion.Version) {
 	writeInfo("Installing %s...", version)
 
 	downloadRelease(version)
-	use(version)
+
+	if useAfterInstall {
+		nocheck = true
+		use(version)
+	}
 }
 
 func buildDownloadURL(version dockerversion.Version) string {
@@ -460,6 +468,7 @@ func use(version dockerversion.Version) {
 		writeDebug("Using alias: %s -> %s", version.Alias, version.SemVer)
 	}
 
+	useAfterInstall = false
 	ensureVersionIsInstalled(version)
 
 	if version.IsSystem() {

--- a/dvm-helper/dvm-helper.go
+++ b/dvm-helper/dvm-helper.go
@@ -244,6 +244,8 @@ func setGlobalVars(c *cli.Context) {
 }
 
 func detect() {
+	writeDebug("dvm detect")
+
 	docker, err := dockerclient.NewEnvClient()
 	if err != nil {
 		die("Cannot build a docker client from environment variables", err, retCodeRuntimeError)
@@ -619,7 +621,6 @@ func isVersionInstalled(version dockerversion.Version) bool {
 	installedVersions := getInstalledVersions("*")
 
 	for _, availableVersion := range installedVersions {
-		writeDebug("Checking version: %s", availableVersion)
 		if version.Equals(availableVersion) {
 			writeDebug("Version %s is installed", version)
 			return true


### PR DESCRIPTION
* Don't call use when use initiated the install.
* Don't validate the Docker version when installing the detected Docker
  version.
* Don't validate the Docker version when using what was just installed,
  or something we know is already installed.