### PR TITLE
Handle leading zeros

### DIFF
--- a/dvm-helper/dockerversion/dockerversion.go
+++ b/dvm-helper/dockerversion/dockerversion.go
@@ -84,25 +84,24 @@ func (version Version) ShouldUseArchivedRelease() bool {
 }
 
 func (version Version) String() string {
-	raw := version.formatRaw()
 	if version.alias != "" && version.semver != nil {
-		return fmt.Sprintf("%s (%s)", version.alias, raw)
+		return fmt.Sprintf("%s (%s)", version.alias, version.formatRaw())
 	}
-	return raw
+	return version.formatRaw()
 }
 
 func (version Version) Value() string {
 	if version.semver == nil {
 		return ""
 	}
-	return version.raw
+	return version.formatRaw()
 }
 
 func (version Version) Name() string {
 	if version.alias != "" {
 		return version.alias
 	}
-	return version.raw
+	return version.formatRaw()
 }
 
 func (version Version) formatRaw() string {

--- a/dvm-helper/dockerversion/dockerversion_test.go
+++ b/dvm-helper/dockerversion/dockerversion_test.go
@@ -1,54 +1,74 @@
-package dockerversion
+package dockerversion_test
 
 import (
 	"testing"
 
+	"github.com/howtowhale/dvm/dvm-helper/dockerversion"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestStripLeadingV(t *testing.T) {
-	v := Parse("v1.0.0")
+	v := dockerversion.Parse("v1.0.0")
 	assert.Equal(t, "1.0.0", v.String())
 }
 
 func TestIsPrerelease(t *testing.T) {
-	var v Version
+	var v dockerversion.Version
 
-	v = Parse("17.3.0-ce-rc1")
+	v = dockerversion.Parse("17.3.0-ce-rc1")
 	assert.True(t, v.IsPrerelease(), "%s should be a prerelease", v)
 
-	v = Parse("1.12.4-rc1")
+	v = dockerversion.Parse("1.12.4-rc1")
 	assert.True(t, v.IsPrerelease(), "%s should be a prerelease", v)
 
-	v = Parse("1.12.4-beta.1")
+	v = dockerversion.Parse("1.12.4-beta.1")
 	assert.True(t, v.IsPrerelease(), "%s should be a prerelease", v)
 
-	v = Parse("1.12.4-alpha-2")
+	v = dockerversion.Parse("1.12.4-alpha-2")
 	assert.True(t, v.IsPrerelease(), "%s should be a prerelease", v)
 
-	v = Parse("17.3.0-ce")
+	v = dockerversion.Parse("17.3.0-ce")
 	assert.False(t, v.IsPrerelease(), "%s should NOT be a prerelease", v)
 }
 
-func TestPrereleasesUseArchivedReleases(t *testing.T) {
-	v := Parse("v1.12.5-rc1")
+func TestPrereleaseUsesArchivedReleases(t *testing.T) {
+	v := dockerversion.Parse("v1.12.5-rc1")
 
 	assert.True(t, v.ShouldUseArchivedRelease())
 }
 
 func TestLeadingZeroInVersion(t *testing.T) {
-	v := Parse("v17.03.0-ce")
+	v := dockerversion.Parse("v17.03.0-ce")
 
 	assert.Equal(t, "17.03.0-ce", v.String(), "Leading zeroes in the version should be preserved")
 }
 
 func TestSystemAlias(t *testing.T) {
-	v := Parse(SystemAlias)
-	assert.Equal(t, SystemAlias, v.String())
+	v := dockerversion.Parse(dockerversion.SystemAlias)
+	assert.Equal(t, dockerversion.SystemAlias, v.String(),
+		"An empty alias should only print the alias")
+	assert.Equal(t, dockerversion.SystemAlias, v.String(),
+		"The name for an aliased version should be its alias")
+	assert.Equal(t, "", v.Value(),
+		"The value for an empty aliased version should be empty")
 }
 
-func TestUserAlias(t *testing.T) {
-	v := Parse("1.2.3")
-	v.Alias = "prod"
-	assert.Equal(t, "prod (1.2.3)", v.String())
+func TestAlias(t *testing.T) {
+	v := dockerversion.NewAlias("prod", "1.2.3")
+	assert.Equal(t, "prod (1.2.3)", v.String(),
+		"The string representation for an aliased version should include both alias and version")
+	assert.Equal(t, "prod", v.Name(),
+		"The name for an aliased version should be its alias")
+	assert.Equal(t, "1.2.3", v.Value(),
+		"The value for an aliased version should be its version")
+}
+
+func TestSemanticVersion(t *testing.T) {
+	v := dockerversion.Parse("1.2.3")
+	assert.Equal(t, "1.2.3", v.String(),
+		"The string representation for a semantic version should only include the semver value")
+	assert.Equal(t, "1.2.3", v.Name(),
+		"The name for a semantic version should be its semver value")
+	assert.Equal(t, "1.2.3", v.Value(),
+		"The value for a semantic version should be its semver value")
 }

--- a/dvm-helper/dockerversion/dockerversion_test.go
+++ b/dvm-helper/dockerversion/dockerversion_test.go
@@ -9,7 +9,9 @@ import (
 
 func TestStripLeadingV(t *testing.T) {
 	v := dockerversion.Parse("v1.0.0")
-	assert.Equal(t, "1.0.0", v.String())
+	assert.Equal(t, "1.0.0", v.String(), "Leading v should be stripped from the string representation")
+	assert.Equal(t, "1.0.0", v.Name(), "Leading v should be stripped from the name")
+	assert.Equal(t, "1.0.0", v.Value(), "Leading v should be stripped from the version value")
 }
 
 func TestIsPrerelease(t *testing.T) {

--- a/dvm-helper/dockerversion/dockerversion_test.go
+++ b/dvm-helper/dockerversion/dockerversion_test.go
@@ -35,3 +35,20 @@ func TestPrereleasesUseArchivedReleases(t *testing.T) {
 
 	assert.True(t, v.ShouldUseArchivedRelease())
 }
+
+func TestLeadingZeroInVersion(t *testing.T) {
+	v := Parse("v17.03.0-ce")
+
+	assert.Equal(t, "17.03.0-ce", v.String(), "Leading zeroes in the version should be preserved")
+}
+
+func TestSystemAlias(t *testing.T) {
+	v := Parse(SystemAlias)
+	assert.Equal(t, SystemAlias, v.String())
+}
+
+func TestUserAlias(t *testing.T) {
+	v := Parse("1.2.3")
+	v.Alias = "prod"
+	assert.Equal(t, "prod (1.2.3)", v.String())
+}


### PR DESCRIPTION
The new Docker version scheme can have leading zeroes in the version parts which isn't strictly compatible with semver. So we must preserve the original string value in order to download and list it
properly.

Fixes #152 