### PR TITLE
Fix URL to windows checksum URL

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -27,7 +27,7 @@ function downloadDvm([string] $dvmDir) {
 
   # Download latest release
   $webClient.DownloadFile("https://howtowhale.github.io/dvm/downloads/latest/Windows/$arch/dvm-helper.exe", "$tmpDir\dvm-helper.exe")
-  $webClient.DownloadFile("https://howtowhale.github.io/dvm/downloads/Windows/$arch/dvm-helper.exe.sha256", "$tmpDir\dvm-helper.exe.256")
+  $webClient.DownloadFile("https://howtowhale.github.io/dvm/downloads/latest/Windows/$arch/dvm-helper.exe.sha256", "$tmpDir\dvm-helper.exe.256")
 
   # Verify the binary was downloaded successfully
   $checksum = (cat $tmpDir\dvm-helper.exe.256).Split(' ')[0]


### PR DESCRIPTION
When I moved the install scripts to their new home, I fat-fingered the Windows checksum URL. Fixes #162 