### PR TITLE
Support "edge" releases

### DIFF
--- a/dvm-helper/dockerversion/dockerversion.go
+++ b/dvm-helper/dockerversion/dockerversion.go
@@ -10,7 +10,7 @@ import (
 )
 
 const SystemAlias = "system"
-const ExperimentalAlias = "experimental"
+const EdgeAlias = "edge"
 
 type Version struct {
 	// Since Docker versions aren't valid versions, (it has leading zeroes)
@@ -44,7 +44,7 @@ func (version Version) BuildDownloadURL(mirror string) (url string, archived boo
 	dockerStoreCutoff, _ := semver.NewVersion("17.06.0-ce")
 
 	var edgeVersion Version
-	if version.IsExperimental() {
+	if version.IsEdge() {
 		// TODO: Figure out the latest edge version
 		edgeVersion, err = findLatestEdgeVersion(mirror)
 		if err != nil {
@@ -53,14 +53,14 @@ func (version Version) BuildDownloadURL(mirror string) (url string, archived boo
 	}
 
 	// Docker Store Download
-	if version.IsExperimental() || !version.semver.LessThan(dockerStoreCutoff) {
+	if version.IsEdge() || !version.semver.LessThan(dockerStoreCutoff) {
 		archived = true
-		checksumed = !version.IsExperimental()
+		checksumed = !version.IsEdge()
 		extSlug = archiveFileExt
 		if mirror == "" {
 			mirror = "download.docker.com"
 		}
-		if version.IsExperimental() {
+		if version.IsEdge() {
 			releaseSlug = "edge"
 			versionSlug = edgeVersion.String()
 		} else if version.IsPrerelease() {
@@ -131,12 +131,12 @@ func (version *Version) SetAsSystem() {
 	version.alias = SystemAlias
 }
 
-func (version Version) IsExperimental() bool {
-	return version.alias == ExperimentalAlias
+func (version Version) IsEdge() bool {
+	return version.alias == EdgeAlias
 }
 
-func (version *Version) SetAsExperimental() {
-	version.alias = ExperimentalAlias
+func (version *Version) SetAsEdge() {
+	version.alias = EdgeAlias
 }
 
 func (version Version) String() string {
@@ -158,7 +158,7 @@ func (version Version) Slug() string {
 	if version.IsSystem() {
 		return ""
 	}
-	if version.IsExperimental() {
+	if version.IsEdge() {
 		return version.alias
 	}
 	return version.formatRaw()

--- a/dvm-helper/dockerversion/dockerversion_test.go
+++ b/dvm-helper/dockerversion/dockerversion_test.go
@@ -53,26 +53,26 @@ func TestSystemAlias(t *testing.T) {
 		"The value for an empty aliased version should be empty")
 }
 
-func TestExperimentalAlias(t *testing.T) {
-	v := Parse(ExperimentalAlias)
-	assert.Equal(t, ExperimentalAlias, v.Slug(),
-		"The slug for the experimental version should be 'experimental'")
-	assert.Equal(t, ExperimentalAlias, v.String(),
+func TestEdgeAlias(t *testing.T) {
+	v := Parse(EdgeAlias)
+	assert.Equal(t, EdgeAlias, v.Slug(),
+		"The slug for the edge version should be 'edge'")
+	assert.Equal(t, EdgeAlias, v.String(),
 		"An empty alias should only print the alias")
-	assert.Equal(t, ExperimentalAlias, v.Name(),
+	assert.Equal(t, EdgeAlias, v.Name(),
 		"The name for an aliased version should be its alias")
 	assert.Equal(t, "", v.Value(),
 		"The value for an empty aliased version should be empty")
 }
 
-func TestExperimentalAliasWithVersion(t *testing.T) {
+func TestEdgeAliasWithVersion(t *testing.T) {
 	v := Parse("17.06.0-ce+02c1d87")
-	v.SetAsExperimental()
-	assert.Equal(t, ExperimentalAlias, v.Slug(),
-		"The slug for the experimental version should be 'experimental'")
-	assert.Equal(t, "experimental (17.06.0-ce+02c1d87)", v.String(),
+	v.SetAsEdge()
+	assert.Equal(t, EdgeAlias, v.Slug(),
+		"The slug for the edge version should be 'edge'")
+	assert.Equal(t, "edge (17.06.0-ce+02c1d87)", v.String(),
 		"The string representation should include the alias and version")
-	assert.Equal(t, ExperimentalAlias, v.Name(),
+	assert.Equal(t, EdgeAlias, v.Name(),
 		"The name for an aliased version should be its alias")
 	assert.Equal(t, "17.06.0-ce+02c1d87", v.Value(),
 		"The value for a populated alias should be the version")
@@ -102,10 +102,10 @@ func TestSemanticVersion(t *testing.T) {
 		"The value for a semantic version should be its semver value")
 }
 
-func TestSetAsExperimental(t *testing.T) {
+func TestSetAsEdge(t *testing.T) {
 	v := Parse("1.2.3")
-	v.SetAsExperimental()
-	assert.True(t, v.IsExperimental())
+	v.SetAsEdge()
+	assert.True(t, v.IsEdge())
 }
 
 func TestSetAsSystem(t *testing.T) {
@@ -170,8 +170,8 @@ func TestVersion_BuildDownloadURL(t *testing.T) {
 	}
 }
 
-func TestVersion_DownloadExperimentalRelease(t *testing.T) {
-	version := Parse("experimental")
+func TestVersion_DownloadEdgeRelease(t *testing.T) {
+	version := Parse("edge")
 
 	url, archived, checksumed, err := version.BuildDownloadURL("")
 	if err != nil {

--- a/dvm-helper/dockerversion/edge_version.go
+++ b/dvm-helper/dockerversion/edge_version.go
@@ -1,0 +1,57 @@
+package dockerversion
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"bytes"
+	"regexp"
+
+	"github.com/pkg/errors"
+)
+
+var hrefRegex = regexp.MustCompile("href=\"docker-(.*).tgz\"")
+
+func findLatestEdgeVersion(mirrorURL string) (Version, error) {
+	if mirrorURL == "" {
+		mirrorURL = "https://download.docker.com"
+	}
+
+	mirror, err := url.Parse(mirrorURL)
+	if err != nil {
+		return Version{}, errors.Wrapf(err, "Unable to parse the mirror URL: %s", mirrorURL)
+	}
+
+	edgeReleasesUrl := fmt.Sprintf("%s://%s/%s/static/edge/%s", mirror.Scheme, mirror.Host, mobyOS, dockerArch)
+	response, err := http.Get(edgeReleasesUrl)
+	if err != nil {
+		return Version{}, errors.Wrapf(err, "Unable to list edge releases at %s", edgeReleasesUrl)
+	}
+	defer response.Body.Close()
+
+	b := bytes.Buffer{}
+	_, err = b.ReadFrom(response.Body)
+	if err != nil {
+	}
+	errors.Wrapf(err, "Unable to read the listing of edge releases at %s", edgeReleasesUrl)
+
+	matches := hrefRegex.FindAllStringSubmatch(b.String(), -1)
+	var results []Version
+	for _, match := range matches {
+		version := Parse(match[1])
+		if version.semver == nil {
+			continue
+		}
+		results = append(results, version)
+	}
+
+	Sort(results)
+
+	if len(results) == 0 {
+		return Version{}, errors.Errorf("No valid edge versions were found at %s", edgeReleasesUrl)
+	}
+
+	last := len(results) - 1
+	return results[last], nil
+}

--- a/dvm-helper/dockerversion/edge_version_test.go
+++ b/dvm-helper/dockerversion/edge_version_test.go
@@ -1,0 +1,28 @@
+package dockerversion
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/howtowhale/dvm/dvm-helper/internal/test"
+)
+
+func TestVersion_findLatestEdgeVersion(t *testing.T) {
+	releaseListing := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprintln(w, test.LoadTestData("edge_releases.html"))
+	}))
+
+	v, err := findLatestEdgeVersion(releaseListing.URL)
+	if err != nil {
+		t.Fatalf("%#v", err)
+	}
+
+	wantV := "17.06.0-ce"
+	gotV := v.String()
+	if wantV != gotV {
+		t.Fatalf("Expected '%s', got '%s'", wantV, gotV)
+	}
+}

--- a/dvm-helper/dockerversion/testdata/edge_releases.html
+++ b/dvm-helper/dockerversion/testdata/edge_releases.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Index of /linux/static/edge/x86_64/</title>
+</head>
+<body>
+<h1>Index of /linux/static/edge/x86_64/</h1>
+<hr>
+<pre><a href="../">../</a>
+<a href="docker-17.03.0-ce.tgz">docker-17.03.0-ce.tgz</a>  2017-03-01 11:46  27M
+<a href="docker-17.04.0-ce.tgz">docker-17.04.0-ce.tgz</a>  2017-04-06 01:07  26M
+<a href="docker-17.05.0-ce.tgz">docker-17.05.0-ce.tgz</a>  2017-05-05 04:11  28M
+<a href="docker-17.06.0-ce.tgz">docker-17.06.0-ce.tgz</a>  2017-06-28 04:51  29M
+</pre><hr></body></html>

--- a/dvm-helper/dvm-helper.go
+++ b/dvm-helper/dvm-helper.go
@@ -442,14 +442,27 @@ func install(version dockerversion.Version) {
 }
 
 func downloadRelease(version dockerversion.Version) {
-	url, archived := version.BuildDownloadURL(mirrorURL)
+	url, archived, checksumed, err := version.BuildDownloadURL(mirrorURL)
+	if err != nil {
+		die("Unable to determine the download URL for %s", err, retCodeRuntimeError, version)
+	}
+
 	binaryName := getBinaryName()
 	binaryPath := filepath.Join(getVersionDir(version), binaryName)
 	if archived {
 		archivedFile := path.Join("docker", binaryName)
-		downloadArchivedFileWithChecksum(url, archivedFile, binaryPath)
+		if checksumed {
+			downloadArchivedFileWithChecksum(url, archivedFile, binaryPath)
+		} else {
+			downloadArchivedFile(url, archivedFile, binaryPath)
+		}
 	} else {
-		downloadFileWithChecksum(url, binaryPath)
+		if checksumed {
+			downloadFileWithChecksum(url, binaryPath)
+		} else {
+			downloadFile(url, binaryPath)
+		}
+
 	}
 	writeDebug("Downloaded Docker %s to %s.", version, binaryPath)
 }

--- a/dvm-helper/dvm-helper.go
+++ b/dvm-helper/dvm-helper.go
@@ -730,12 +730,13 @@ func getExperimentalDockerVersion() (dockerversion.Version, error) {
 }
 
 func getDockerVersion(dockerPath string, includeBuild bool) (dockerversion.Version, error) {
-	rawVersion, _ := exec.Command(dockerPath, "-v").Output()
+	stdout, _ := exec.Command(dockerPath, "-v").Output()
+	rawVersion := strings.TrimSpace(string(stdout))
 
 	writeDebug("%s -v output: %s", dockerPath, rawVersion)
 
-	versionRegex := regexp.MustCompile(`^Docker version (.+), build ([^,]+),?`)
-	match := versionRegex.FindSubmatch(rawVersion)
+	versionRegex := regexp.MustCompile(`^Docker version (.+), build (.+)?`)
+	match := versionRegex.FindStringSubmatch(rawVersion)
 	if len(match) < 2 {
 		return dockerversion.Version{}, errors.New("Could not detect docker version.")
 	}

--- a/dvm-helper/dvm-helper.go
+++ b/dvm-helper/dvm-helper.go
@@ -81,7 +81,7 @@ func makeCliApp() *cli.App {
 		{
 			Name:    "install",
 			Aliases: []string{"i"},
-			Usage:   "dvm install [<version>], dvm install experimental\n\tInstall a Docker version, using $DOCKER_VERSION if the version is not specified.",
+			Usage:   "dvm install [<version>], dvm install edge\n\tInstall a Docker version, using $DOCKER_VERSION if the version is not specified.",
 			Flags: []cli.Flag{
 				cli.StringFlag{Name: "mirror-url", EnvVar: "DVM_MIRROR_URL", Usage: "Specify an alternate URL from which to download the Docker client. Defaults to https://get.docker.com/builds"},
 				cli.BoolFlag{Name: "nocheck", EnvVar: "DVM_NOCHECK", Usage: "Do not check if version exists (use with caution)."},
@@ -121,7 +121,7 @@ func makeCliApp() *cli.App {
 		},
 		{
 			Name:  "use",
-			Usage: "dvm use [<version>], dvm use system, dvm use experimental\n\tUse a Docker version, using $DOCKER_VERSION if the version is not specified.",
+			Usage: "dvm use [<version>], dvm use system, dvm use edge\n\tUse a Docker version, using $DOCKER_VERSION if the version is not specified.",
 			Flags: []cli.Flag{
 				cli.StringFlag{Name: "mirror-url", EnvVar: "DVM_MIRROR_URL", Usage: "Specify an alternate URL from which to download the Docker client. Defaults to https://get.docker.com/builds"},
 				cli.BoolFlag{Name: "nocheck", EnvVar: "DVM_NOCHECK", Usage: "Do not check if version exists (use with caution)."},
@@ -416,11 +416,11 @@ func install(version dockerversion.Version) {
 
 	versionDir := getVersionDir(version)
 
-	if version.IsExperimental() && pathExists(versionDir) {
-		// Always install latest of experimental build
+	if version.IsEdge() && pathExists(versionDir) {
+		// Always install latest of edge build
 		err := os.RemoveAll(versionDir)
 		if err != nil {
-			die("Unable to remove experimental version at %s.", err, retCodeRuntimeError, versionDir)
+			die("Unable to remove edge version at %s.", err, retCodeRuntimeError, versionDir)
 		}
 	}
 
@@ -499,8 +499,8 @@ func use(version dockerversion.Version) {
 
 	if version.IsSystem() {
 		version, _ = getSystemDockerVersion()
-	} else if version.IsExperimental() {
-		version, _ = getExperimentalDockerVersion()
+	} else if version.IsEdge() {
+		version, _ = getEdgeDockerVersion()
 	}
 
 	removePreviousDockerVersionFromPath()
@@ -648,7 +648,7 @@ func isVersionInstalled(version dockerversion.Version) bool {
 }
 
 func versionExists(version dockerversion.Version) bool {
-	if version.IsExperimental() {
+	if version.IsEdge() {
 		return true
 	}
 
@@ -674,21 +674,21 @@ func getCurrentDockerVersion() (dockerversion.Version, error) {
 	}
 
 	systemDockerPath, _ := getSystemDockerPath()
-	experimentalVersionPath, _ := getExperimentalDockerPath()
+	edgeVersionPath, _ := getEdgeDockerPath()
 
 	isSystem := currentDockerPath == systemDockerPath
-	isExperimental := currentDockerPath == experimentalVersionPath
+	isEdge := currentDockerPath == edgeVersionPath
 
-	current, _ := getDockerVersion(currentDockerPath, isExperimental)
+	current, _ := getDockerVersion(currentDockerPath, isEdge)
 
 	if isSystem {
 		writeDebug("The current docker is the system installation")
 		current.SetAsSystem()
 	}
 
-	if isExperimental {
-		writeDebug("The current docker is an experimental version")
-		current.SetAsExperimental()
+	if isEdge {
+		writeDebug("The current docker is an edge version")
+		current.SetAsEdge()
 	}
 
 	writeDebug("The current version is: %s", current)
@@ -713,19 +713,19 @@ func getSystemDockerVersion() (dockerversion.Version, error) {
 	return version, err
 }
 
-func getExperimentalDockerPath() (string, error) {
-	experimentalVersionPath := filepath.Join(getVersionsDir(), dockerversion.ExperimentalAlias, getBinaryName())
-	_, err := os.Stat(experimentalVersionPath)
-	return experimentalVersionPath, err
+func getEdgeDockerPath() (string, error) {
+	edgeVersionPath := filepath.Join(getVersionsDir(), dockerversion.EdgeAlias, getBinaryName())
+	_, err := os.Stat(edgeVersionPath)
+	return edgeVersionPath, err
 }
 
-func getExperimentalDockerVersion() (dockerversion.Version, error) {
-	experimentalDockerpath, err := getExperimentalDockerPath()
+func getEdgeDockerVersion() (dockerversion.Version, error) {
+	edgeDockerpath, err := getEdgeDockerPath()
 	if err != nil {
 		return dockerversion.Version{}, err
 	}
-	version, err := getDockerVersion(experimentalDockerpath, true)
-	version.SetAsExperimental()
+	version, err := getDockerVersion(edgeDockerpath, true)
+	version.SetAsEdge()
 	return version, err
 }
 
@@ -767,14 +767,14 @@ func getInstalledVersions(pattern string) []dockerversion.Version {
 	for _, versionDir := range versions {
 		version := dockerversion.Parse(filepath.Base(versionDir))
 
-		if version.IsExperimental() {
-			experimentalDockerPath := filepath.Join(versionDir, getBinaryName())
-			experimentalVersion, err := getDockerVersion(experimentalDockerPath, true)
+		if version.IsEdge() {
+			edgeDockerPath := filepath.Join(versionDir, getBinaryName())
+			edgeVersion, err := getDockerVersion(edgeDockerPath, true)
 			if err != nil {
-				writeDebug("Unable to get version of installed experimental version at %s.\n%s", versionDir, err)
+				writeDebug("Unable to get version of installed edge version at %s.\n%s", versionDir, err)
 				continue
 			}
-			version = dockerversion.NewAlias(dockerversion.ExperimentalAlias, experimentalVersion.Value())
+			version = dockerversion.NewAlias(dockerversion.EdgeAlias, edgeVersion.Value())
 		}
 
 		results = append(results, version)
@@ -867,8 +867,8 @@ func getVersionsDir() string {
 
 func getVersionDir(version dockerversion.Version) string {
 	versionPath := version.Slug()
-	if version.IsExperimental() {
-		versionPath = dockerversion.ExperimentalAlias
+	if version.IsEdge() {
+		versionPath = dockerversion.EdgeAlias
 	}
 	return filepath.Join(getVersionsDir(), versionPath)
 }

--- a/dvm-helper/dvm-helper.nix.go
+++ b/dvm-helper/dvm-helper.nix.go
@@ -21,7 +21,7 @@ func upgradeSelf(version string) {
 
 func getCleanPathRegex() string {
 	versionDir := getVersionsDir()
-	return versionDir + `/(\d+\.\d+\.\d+|experimental):`
+	return versionDir + `/(\d+\.\d+\.\d+|edge):`
 }
 
 func validateShellFlag() {

--- a/dvm-helper/dvm-helper.windows.go
+++ b/dvm-helper/dvm-helper.windows.go
@@ -46,7 +46,7 @@ func writeUpgradeScript() {
 func getCleanPathRegex() string {
 	versionDir := getVersionsDir()
 	escapedVersionDir := strings.Replace(versionDir, `\`, `\\`, -1)
-	return escapedVersionDir + `\\(\d+\.\d+\.\d+|experimental);`
+	return escapedVersionDir + `\\(\d+\.\d+\.\d+|edge);`
 }
 
 func validateShellFlag() {

--- a/dvm-helper/dvm-helper_test.go
+++ b/dvm-helper/dvm-helper_test.go
@@ -3,14 +3,13 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/fatih/color"
+	"github.com/howtowhale/dvm/dvm-helper/internal/test"
 	"github.com/ryanuber/go-glob"
 	"github.com/stretchr/testify/assert"
 )
@@ -49,7 +48,7 @@ func githubReleasesHandler(w http.ResponseWriter, r *http.Request) {
 
 	switch r.RequestURI {
 	case "/repos/docker/docker/releases?per_page=100":
-		fmt.Fprintln(w, loadTestData("github-docker-releases.json"))
+		fmt.Fprintln(w, test.LoadTestData("github-docker-releases.json"))
 	default:
 		w.WriteHeader(404)
 	}
@@ -156,18 +155,4 @@ func TestInstallPrereleases(t *testing.T) {
 	output := outputCapture.String()
 	assert.NotEmpty(t, output, "Should have captured stdout")
 	assert.Contains(t, output, "Now using Docker 1.12.5-rc1", "Should have installed a prerelease version")
-}
-
-func loadTestData(src string) string {
-	pwd, err := os.Getwd()
-	if err != nil {
-		panic(err)
-	}
-
-	testFile := filepath.Join(pwd, "testdata", src)
-	content, err := ioutil.ReadFile(testFile)
-	if err != nil {
-		panic(err)
-	}
-	return string(content)
 }

--- a/dvm-helper/internal/test/testdata.go
+++ b/dvm-helper/internal/test/testdata.go
@@ -1,0 +1,23 @@
+package test
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+// LoadTestData reads the relative path under the testdata directory
+// and returns the contents.
+func LoadTestData(src string) string {
+	pwd, err := os.Getwd()
+	if err != nil {
+		panic(err)
+	}
+
+	testFile := filepath.Join(pwd, "testdata", src)
+	content, err := ioutil.ReadFile(testFile)
+	if err != nil {
+		panic(err)
+	}
+	return string(content)
+}

--- a/dvm-helper/util.go
+++ b/dvm-helper/util.go
@@ -101,16 +101,24 @@ func downloadFileWithChecksum(url string, destPath string) {
 	}
 }
 
+func downloadArchivedFile(url string, archivedFile string, destPath string) {
+	archiveName := path.Base(url)
+	tmpPath := filepath.Join(dvmDir, ".tmp", archiveName)
+	downloadFile(url, tmpPath)
+	extractArchive(tmpPath, archiveName, archivedFile, destPath)
+}
+
 func downloadArchivedFileWithChecksum(url string, archivedFile string, destPath string) {
 	archiveName := path.Base(url)
 	tmpPath := filepath.Join(dvmDir, ".tmp", archiveName)
 	downloadFileWithChecksum(url, tmpPath)
-
+	extractArchive(tmpPath, archiveName, archivedFile, destPath)
+}
+func extractArchive(tmpPath string, archiveName string, archivedFile string, destPath string) {
 	// Extract the archive
 	archivePath := filepath.Join(dvmDir, ".tmp", strings.TrimSuffix(archiveName, filepath.Ext(archiveName)))
 	extractor := extractor.NewDetectable()
 	extractor.Extract(tmpPath, archivePath)
-
 	// Copy the archived file to the final destination
 	archivedFilePath := filepath.Join(archivePath, archivedFile)
 	ensureParentDirectoryExists(destPath)
@@ -118,7 +126,6 @@ func downloadArchivedFileWithChecksum(url string, archivedFile string, destPath 
 	if err != nil {
 		die("Unable to copy %s to %s.", err, retCodeRuntimeError, archivedFilePath, destPath)
 	}
-
 	// Cleanup temp files
 	if err = os.Remove(tmpPath); err != nil {
 		writeWarning("Unable to remove temporary file: %s\n%s", tmpPath, err)


### PR DESCRIPTION
Fixes #169, so that `dvm install edge` works. It lists the contents of `https://download.docker.com/OS/static/edge/ARCH/` and installs the latest version.

I've renamed from experimental to edge because that's what Docker calls these builds now. This is a breaking change but since it hasn't been working for months (because docker stopped releasing to the old static url), it's already broken.