### PR TITLE
Use built-in Change Directory(cd) command

### DIFF
--- a/dvm.sh
+++ b/dvm.sh
@@ -27,7 +27,7 @@ fi
 if [ -n "$BASH_SOURCE" ]; then
   DVM_SCRIPT_SOURCE="${BASH_SOURCE[0]}"
 fi
-export DVM_HELPER="$(command cd $DVM_CD_FLAGS "$(dirname "${DVM_SCRIPT_SOURCE:-$0}")" > /dev/null && command pwd)/dvm-helper/dvm-helper"
+export DVM_HELPER="$(builtin cd $DVM_CD_FLAGS "$(dirname "${DVM_SCRIPT_SOURCE:-$0}")" > /dev/null && command pwd)/dvm-helper/dvm-helper"
 unset DVM_SCRIPT_SOURCE 2> /dev/null
 
 dvm() {

--- a/dvm.sh
+++ b/dvm.sh
@@ -27,7 +27,14 @@ fi
 if [ -n "$BASH_SOURCE" ]; then
   DVM_SCRIPT_SOURCE="${BASH_SOURCE[0]}"
 fi
-export DVM_HELPER="$(builtin cd $DVM_CD_FLAGS "$(dirname "${DVM_SCRIPT_SOURCE:-$0}")" > /dev/null && command pwd)/dvm-helper/dvm-helper"
+
+if command -v builtin >/dev/null 2>&1; then
+  export DVM_HELPER="$(builtin cd $DVM_CD_FLAGS "$(dirname "${DVM_SCRIPT_SOURCE:-$0}")" > /dev/null && command pwd)/dvm-helper/dvm-helper"
+else
+  export DVM_HELPER="$(cd $DVM_CD_FLAGS "$(dirname "${DVM_SCRIPT_SOURCE:-$0}")" > /dev/null && command pwd)/dvm-helper/dvm-helper"
+fi
+
+
 unset DVM_SCRIPT_SOURCE 2> /dev/null
 
 dvm() {

--- a/dvm.sh
+++ b/dvm.sh
@@ -27,14 +27,11 @@ fi
 if [ -n "$BASH_SOURCE" ]; then
   DVM_SCRIPT_SOURCE="${BASH_SOURCE[0]}"
 fi
-
 if command -v builtin >/dev/null 2>&1; then
   export DVM_HELPER="$(builtin cd $DVM_CD_FLAGS "$(dirname "${DVM_SCRIPT_SOURCE:-$0}")" > /dev/null && command pwd)/dvm-helper/dvm-helper"
 else
   export DVM_HELPER="$(cd $DVM_CD_FLAGS "$(dirname "${DVM_SCRIPT_SOURCE:-$0}")" > /dev/null && command pwd)/dvm-helper/dvm-helper"
 fi
-
-
 unset DVM_SCRIPT_SOURCE 2> /dev/null
 
 dvm() {


### PR DESCRIPTION
## The problem

When we use **command** to execute any **built-in** command, first it'll look inside the **PATH** variable for any command that the argument passed may match, if it finds any command that match, then it'll execute that command, if it doesn't find any command in the **PATH**, then it'll look for **built-in** commands of your **command shell** and then execute it.

OSX has a **cd** command located at `/usr/bin/cd` and in general it's inside the **PATH** variable. But if you use **ZSH** or any other shell, you should be using their **built-in** commands.

For example, for who use **ZSH**, the **built-in** commands may be located at `/usr/local/Cellar/zsh/<zsh_version>/share/zsh/functions`. And in this case the **built-in** **cd** command it's inside this folder, more precisely at `/usr/local/Cellar/zsh/5.4.2_1/share/zsh/functions/_cd`.

As you can see on [zsh](https://github.com/zsh-users/zsh) repository, the [**cd**](https://github.com/zsh-users/zsh/blob/master/Completion/Zsh/Command/_cd#L16) command has the **-q** option.

## The solution

So, the solution is to use the **builtin** command, which looks directly inside the **built-in** commands, skipping the **PATH** part.

Fixes #144 
