### PR TITLE
 New releases are no longer published with a checksum 

### DIFF
--- a/dvm-helper/dockerversion/dockerversion.go
+++ b/dvm-helper/dockerversion/dockerversion.go
@@ -55,7 +55,7 @@ func (version Version) BuildDownloadURL(mirror string) (url string, archived boo
 	// Docker Store Download
 	if version.IsEdge() || !version.semver.LessThan(dockerStoreCutoff) {
 		archived = true
-		checksumed = !version.IsEdge()
+		checksumed = false
 		extSlug = archiveFileExt
 		if mirror == "" {
 			mirror = "download.docker.com"


### PR DESCRIPTION
Fixes #179 by not using checksums for the new download location (e.g. https://download.docker.com/mac/static/stable/x86_64/).