### PR TITLE
Fix ls-remote

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ validate:
 	-go list ./... | grep -v /vendor/ | xargs -L1 golint --set_exit_status
 
 test: local
-	go test -v $(GOFILES_NOVENDOR)
+	go test $(GOFILES_NOVENDOR)
 	eval "$( ./dvm-helper --bash-completion )"
 	./dvm-helper/dvm-helper --version
 

--- a/dvm-helper/dockerversion/dockerversion.go
+++ b/dvm-helper/dockerversion/dockerversion.go
@@ -45,7 +45,6 @@ func (version Version) BuildDownloadURL(mirror string) (url string, archived boo
 
 	var edgeVersion Version
 	if version.IsEdge() {
-		// TODO: Figure out the latest edge version
 		edgeVersion, err = findLatestEdgeVersion(mirror)
 		if err != nil {
 			return

--- a/dvm-helper/dockerversion/edge_version.go
+++ b/dvm-helper/dockerversion/edge_version.go
@@ -1,55 +1,9 @@
 package dockerversion
 
-import (
-	"fmt"
-	"net/http"
-	"net/url"
-
-	"bytes"
-	"regexp"
-
-	"github.com/pkg/errors"
-)
-
-var hrefRegex = regexp.MustCompile("href=\"docker-(.*).tgz\"")
-
 func findLatestEdgeVersion(mirrorURL string) (Version, error) {
-	if mirrorURL == "" {
-		mirrorURL = "https://download.docker.com"
-	}
-
-	mirror, err := url.Parse(mirrorURL)
+	results, err := ListVersions(mirrorURL, Edge)
 	if err != nil {
-		return Version{}, errors.Wrapf(err, "Unable to parse the mirror URL: %s", mirrorURL)
-	}
-
-	edgeReleasesUrl := fmt.Sprintf("%s://%s/%s/static/edge/%s", mirror.Scheme, mirror.Host, mobyOS, dockerArch)
-	response, err := http.Get(edgeReleasesUrl)
-	if err != nil {
-		return Version{}, errors.Wrapf(err, "Unable to list edge releases at %s", edgeReleasesUrl)
-	}
-	defer response.Body.Close()
-
-	b := bytes.Buffer{}
-	_, err = b.ReadFrom(response.Body)
-	if err != nil {
-	}
-	errors.Wrapf(err, "Unable to read the listing of edge releases at %s", edgeReleasesUrl)
-
-	matches := hrefRegex.FindAllStringSubmatch(b.String(), -1)
-	var results []Version
-	for _, match := range matches {
-		version := Parse(match[1])
-		if version.semver == nil {
-			continue
-		}
-		results = append(results, version)
-	}
-
-	Sort(results)
-
-	if len(results) == 0 {
-		return Version{}, errors.Errorf("No valid edge versions were found at %s", edgeReleasesUrl)
+		return Version{}, err
 	}
 
 	last := len(results) - 1

--- a/dvm-helper/dockerversion/query.go
+++ b/dvm-helper/dockerversion/query.go
@@ -1,0 +1,64 @@
+package dockerversion
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"regexp"
+
+	"github.com/pkg/errors"
+)
+
+type ReleaseType string
+
+const (
+	Edge   ReleaseType = "edge"
+	Test   ReleaseType = "test"
+	Stable ReleaseType = "stable"
+)
+
+var hrefRegex = regexp.MustCompile(fmt.Sprintf(`href="docker-(.*)\%s"`, archiveFileExt))
+
+func ListVersions(mirrorURL string, releaseType ReleaseType) ([]Version, error) {
+	if mirrorURL == "" {
+		mirrorURL = "https://download.docker.com"
+	}
+
+	mirror, err := url.Parse(mirrorURL)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Unable to parse the mirror URL: %s", mirrorURL)
+	}
+
+	indexURL := fmt.Sprintf("%s://%s/%s/static/%s/%s", mirror.Scheme, mirror.Host, mobyOS, releaseType, dockerArch)
+	response, err := http.Get(indexURL)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Unable to list %s releases at %s", releaseType, indexURL)
+	}
+	defer response.Body.Close()
+
+	b := bytes.Buffer{}
+	_, err = b.ReadFrom(response.Body)
+	if err != nil {
+	}
+	errors.Wrapf(err, "Unable to read the listing of %s releases at %s", releaseType, indexURL)
+
+	matches := hrefRegex.FindAllStringSubmatch(b.String(), -1)
+	var results []Version
+	for _, match := range matches {
+		version := Parse(match[1])
+		if version.semver == nil {
+			continue
+		}
+		results = append(results, version)
+	}
+
+	if len(results) == 0 {
+		return nil, errors.Errorf("No valid %s versions were found at %s", releaseType, indexURL)
+	}
+
+	Sort(results)
+
+	return results, nil
+}

--- a/dvm-helper/dvm-helper.go
+++ b/dvm-helper/dvm-helper.go
@@ -393,7 +393,7 @@ func list(pattern string) {
 	current, _ := getCurrentDockerVersion()
 
 	for _, version := range versions {
-		if current.Equals(version) {
+		if current.String() == version.String() {
 			color.Green("->\t%s", version)
 		} else {
 			writeInfo("\t%s", version)

--- a/dvm-helper/dvm-helper.nix.go
+++ b/dvm-helper/dvm-helper.nix.go
@@ -21,7 +21,7 @@ func upgradeSelf(version string) {
 
 func getCleanPathRegex() string {
 	versionDir := getVersionsDir()
-	return versionDir + `/(\d+\.\d+\.\d+|edge):`
+	return versionDir + `/[^:]+:`
 }
 
 func validateShellFlag() {

--- a/dvm-helper/dvm-helper.windows.go
+++ b/dvm-helper/dvm-helper.windows.go
@@ -46,7 +46,7 @@ func writeUpgradeScript() {
 func getCleanPathRegex() string {
 	versionDir := getVersionsDir()
 	escapedVersionDir := strings.Replace(versionDir, `\`, `\\`, -1)
-	return escapedVersionDir + `\\(\d+\.\d+\.\d+|edge);`
+	return escapedVersionDir + `\\[^:]+;`
 }
 
 func validateShellFlag() {

--- a/dvm-helper/dvm-helper_test.go
+++ b/dvm-helper/dvm-helper_test.go
@@ -47,7 +47,7 @@ func githubReleasesHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
 	switch r.RequestURI {
-	case "/repos/docker/docker/releases?per_page=100":
+	case "/repos/moby/moby/releases?per_page=100":
 		fmt.Fprintln(w, test.LoadTestData("github-docker-releases.json"))
 	default:
 		w.WriteHeader(404)
@@ -118,12 +118,16 @@ func TestListRemote(t *testing.T) {
 	color.Output = outputCapture
 
 	dvm := makeCliApp()
-	dvm.Run([]string{"dvm", "--debug", "list-remote", "1.12"})
+	dvm.Run([]string{"dvm", "--debug", "list-remote"})
 
 	output := outputCapture.String()
 	assert.NotEmpty(t, output, "Should have captured stdout")
-	assert.NotContains(t, output, "1.12.5-rc1", "Should not have listed a prerelease version")
 
+	assert.Contains(t, output, "1.12.5", "Should have listed a legacy stable version")
+	assert.NotContains(t, output, "1.12.5-rc1", "Should not have listed a legacy prerelease version")
+
+	assert.Contains(t, output, "17.09.0-ce", "Should have listed a stable version")
+	assert.NotContains(t, output, "17.10.0-ce-rc1", "Should not have listed a prerelease version")
 }
 
 func TestListRemoteWithPrereleases(t *testing.T) {
@@ -134,12 +138,13 @@ func TestListRemoteWithPrereleases(t *testing.T) {
 	color.Output = outputCapture
 
 	dvm := makeCliApp()
-	dvm.Run([]string{"dvm-helper", "--debug", "list-remote", "--pre", "1.12"})
+	dvm.Run([]string{"dvm-helper", "--debug", "list-remote", "--pre"})
 
 	output := outputCapture.String()
 	assert.NotEmpty(t, output, "Should have captured stdout")
-	assert.Contains(t, output, "1.12.5-rc1", "Should have listed a prerelease version")
 
+	assert.Contains(t, output, "1.12.5-rc1", "Should have listed a legacy prerelease version")
+	assert.Contains(t, output, "17.10.0-ce-rc1", "Should have listed a prerelease version")
 }
 
 func TestInstallPrereleases(t *testing.T) {


### PR DESCRIPTION
 `ls-remote` now hits up the old tags, and checks in the new fileshare locations for all the versions (both prerelease and stable).

Related to #170.