### PR TITLE
Retry failed release downloads from test location 

### DIFF
--- a/dvm-helper/dvm-helper.nix.go
+++ b/dvm-helper/dvm-helper.nix.go
@@ -5,18 +5,28 @@ package main
 import (
 	"os"
 	"path/filepath"
+
+	"github.com/howtowhale/dvm/dvm-helper/internal/downloader"
 )
 
 const binaryFileExt string = ""
 
 func upgradeSelf(version string) {
+	d := downloader.New(getDebugLogger())
+
 	binaryURL := buildDvmReleaseURL(version, dvmOS, dvmArch, "dvm-helper")
 	binaryPath := filepath.Join(dvmDir, "dvm-helper", "dvm-helper")
-	downloadFileWithChecksum(binaryURL, binaryPath)
+	err := d.DownloadFileWithChecksum(binaryURL, binaryPath)
+	if err != nil {
+		die("", err, retCodeRuntimeError)
+	}
 
 	scriptURL := buildDvmReleaseURL(version, "dvm.sh")
 	scriptPath := filepath.Join(dvmDir, "dvm.sh")
-	downloadFile(scriptURL, scriptPath)
+	err = d.DownloadFile(scriptURL, scriptPath)
+	if err != nil {
+		die("", err, retCodeRuntimeError)
+	}
 }
 
 func getCleanPathRegex() string {

--- a/dvm-helper/dvm-helper.windows.go
+++ b/dvm-helper/dvm-helper.windows.go
@@ -6,24 +6,37 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
+
+	"github.com/howtowhale/dvm/dvm-helper/internal/downloader"
 )
-import "strings"
 
 const dvmOS string = "Windows"
 const binaryFileExt string = ".exe"
 
 func upgradeSelf(version string) {
+	d := downloader.New(getDebugLogger())
+
 	binaryURL := buildDvmReleaseURL(version, dvmOS, dvmArch, "dvm-helper.exe")
 	binaryPath := filepath.Join(dvmDir, ".tmp", "dvm-helper.exe")
-	downloadFileWithChecksum(binaryURL, binaryPath)
+	err := d.DownloadFileWithChecksum(binaryURL, binaryPath)
+	if err != nil {
+		die("", err, retCodeRuntimeError)
+	}
 
 	psScriptURL := buildDvmReleaseURL(version, "dvm.ps1")
 	psScriptPath := filepath.Join(dvmDir, "dvm.ps1")
-	downloadFile(psScriptURL, psScriptPath)
+	err = d.DownloadFile(psScriptURL, psScriptPath)
+	if err != nil {
+		die("", err, retCodeRuntimeError)
+	}
 
 	cmdScriptURL := buildDvmReleaseURL(version, "dvm.cmd")
 	cmdScriptPath := filepath.Join(dvmDir, "dvm.cmd")
-	downloadFile(cmdScriptURL, cmdScriptPath)
+	err = d.DownloadFile(cmdScriptURL, cmdScriptPath)
+	if err != nil {
+		die("", err, retCodeRuntimeError)
+	}
 
 	writeUpgradeScript()
 }

--- a/dvm-helper/dvm-helper_test.go
+++ b/dvm-helper/dvm-helper_test.go
@@ -156,3 +156,35 @@ func TestInstallPrereleases(t *testing.T) {
 	assert.NotEmpty(t, output, "Should have captured stdout")
 	assert.Contains(t, output, "Now using Docker 1.12.5-rc1", "Should have installed a prerelease version")
 }
+
+// install a version from the test location that is missing the -rc suffix
+func TestInstallNonPrereleaseTestRelease(t *testing.T) {
+	_, github := createMockDVM(nil)
+	defer github.Close()
+
+	outputCapture := &bytes.Buffer{}
+	color.Output = outputCapture
+
+	dvm := makeCliApp()
+	dvm.Run([]string{"dvm-helper", "--debug", "install", "17.10.0-ce"})
+
+	output := outputCapture.String()
+	assert.NotEmpty(t, output, "Should have captured stdout")
+	assert.Contains(t, output, "Now using Docker 17.10.0-ce", "Should have installed a test version")
+}
+
+// install something that used to be a test release and is now considered stable
+func TestInstallStabilizedTestRelease(t *testing.T) {
+	_, github := createMockDVM(nil)
+	defer github.Close()
+
+	outputCapture := &bytes.Buffer{}
+	color.Output = outputCapture
+
+	dvm := makeCliApp()
+	dvm.Run([]string{"dvm-helper", "--debug", "install", "17.09.0-ce"})
+
+	output := outputCapture.String()
+	assert.NotEmpty(t, output, "Should have captured stdout")
+	assert.Contains(t, output, "Now using Docker 17.09.0-ce", "Should have installed a stable version")
+}

--- a/dvm-helper/internal/downloader/downloader.go
+++ b/dvm-helper/internal/downloader/downloader.go
@@ -1,0 +1,177 @@
+package downloader
+
+import (
+	"io"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/howtowhale/dvm/dvm-helper/checksum"
+	"github.com/pivotal-golang/archiver/extractor"
+	"github.com/pkg/errors"
+)
+
+// Client is capable of downloading archived and checksumed files.
+type Client struct {
+	log *log.Logger
+	tmp string
+}
+
+// New creates a downloader client.
+// l - optional logger for debug output
+func New(l *log.Logger) Client {
+	if l == nil {
+		l = log.New(ioutil.Discard, "", log.LstdFlags)
+	}
+	tmpDir, _ := ioutil.TempDir("", "dvm")
+
+	return Client{
+		log: l, tmp: tmpDir}
+}
+
+func (d Client) ensureParentDirectoryExists(path string) error {
+	err := os.MkdirAll(filepath.Dir(path), os.ModePerm)
+	return errors.Wrapf(err, "Unable to create parent directory %s", path)
+}
+
+// DownloadFile saves a file without any additional processing.
+func (d Client) DownloadFile(url string, destPath string) error {
+	err := d.ensureParentDirectoryExists(destPath)
+	if err != nil {
+		return err
+	}
+
+	destFile, err := os.Create(destPath)
+	if err != nil {
+		return errors.Wrapf(err, "Unable to create %s", destPath)
+	}
+	defer destFile.Close()
+	os.Chmod(destPath, 0755)
+
+	d.log.Printf("Downloading %s\n", url)
+
+	response, err := http.Get(url)
+	if err != nil {
+		return errors.Wrapf(err, "Unable to download %s", url)
+	}
+
+	if response.StatusCode != 200 {
+		return errors.Wrapf(err, "Unable to download %s (Status %d)", url, response.StatusCode)
+	}
+	defer response.Body.Close()
+
+	_, err = io.Copy(destFile, response.Body)
+	return errors.Wrapf(err, "Unable to write to %s", destPath)
+}
+
+// Download file saves a file after verifying the checksum found at url + ".sh256".
+func (d Client) DownloadFileWithChecksum(url string, destPath string) error {
+	fileName := filepath.Base(destPath)
+	tmpPath := filepath.Join(d.tmp, fileName)
+	err := d.DownloadFile(url, tmpPath)
+	if err != nil {
+		return err
+	}
+
+	checksumURL := url + ".sha256"
+	checksumPath := filepath.Join(d.tmp, fileName+".sha256")
+	err = d.DownloadFile(checksumURL, checksumPath)
+	if err != nil {
+		return err
+	}
+
+	isValid, err := checksum.CompareChecksum(tmpPath, checksumPath)
+	if err != nil {
+		return errors.Wrapf(err, "Unable to calculate checksum of %s", tmpPath)
+	}
+	if !isValid {
+		return errors.Wrapf(err, "The checksum of %s failed to match %s", tmpPath, checksumPath)
+	}
+
+	// Copy to final location, if different
+	if destPath != tmpPath {
+		err = d.ensureParentDirectoryExists(destPath)
+		if err != nil {
+			return err
+		}
+
+		err = os.Rename(tmpPath, destPath)
+		if err != nil {
+			return errors.Wrapf(err, "Unable to copy %s to %s", tmpPath, destPath)
+		}
+	}
+
+	// Cleanup temp files
+	if err = os.Remove(checksumPath); err != nil {
+		d.log.Println(errors.Wrapf(err, "Unable to remove temporary file %s", checksumPath))
+	}
+
+	return nil
+}
+
+// DownloadArchivedFile downloads the archive, decompresses it and saves the specified file to the destination path.
+// url - URL of the archived file, e.g. a gzip, zip or tar file
+// archivedFile - relative path to the desired file in the archive
+// destPath - location where the archivedFile should be saved
+func (d Client) DownloadArchivedFile(url string, archivedFile string, destPath string) error {
+	archiveName := path.Base(url)
+	tmpPath := filepath.Join(d.tmp, archiveName)
+
+	err := d.DownloadFile(url, tmpPath)
+	if err != nil {
+		return err
+	}
+
+	return d.extractArchive(tmpPath, archiveName, archivedFile, destPath)
+}
+
+// DownloadArchivedFileWithChecksum first verifies the checksum found at url + ".sh256",
+// decompresses the archive, and then saves the specified file to the destination path.
+// url - URL of the archived file, e.g. a gzip, zip or tar file
+// archivedFile - relative path to the desired file in the archive
+// destPath - location where the archivedFile should be saved
+func (d Client) DownloadArchivedFileWithChecksum(url string, archivedFile string, destPath string) error {
+	archiveName := path.Base(url)
+	tmpPath := filepath.Join(d.tmp, archiveName)
+
+	err := d.DownloadFileWithChecksum(url, tmpPath)
+	if err != nil {
+		return err
+	}
+
+	return d.extractArchive(tmpPath, archiveName, archivedFile, destPath)
+}
+
+func (d Client) extractArchive(tmpPath string, archiveName string, archivedFile string, destPath string) error {
+	// Extract the archive
+	archivePath := filepath.Join(d.tmp, strings.TrimSuffix(archiveName, filepath.Ext(archiveName)))
+	x := extractor.NewDetectable()
+	x.Extract(tmpPath, archivePath)
+
+	// Copy the archived file to the final destination
+	archivedFilePath := filepath.Join(archivePath, archivedFile)
+
+	err := d.ensureParentDirectoryExists(destPath)
+	if err != nil {
+		return err
+	}
+
+	err = os.Rename(archivedFilePath, destPath)
+	if err != nil {
+		return errors.Wrapf(err, "Unable to copy %s to %s", archivedFilePath, destPath)
+	}
+
+	// Cleanup temp files
+	if err = os.Remove(tmpPath); err != nil {
+		d.log.Println(errors.Wrapf(err, "Unable to remove temporary file %s", tmpPath))
+	}
+	if err = os.RemoveAll(archivePath); err != nil {
+		d.log.Println(errors.Wrapf(err, "Unable to remove temporary directory %s", archivePath))
+	}
+
+	return nil
+}

--- a/dvm-helper/util.go
+++ b/dvm-helper/util.go
@@ -1,15 +1,13 @@
 package main
 
-import "fmt"
-import "io"
-import "net/http"
-import "os"
-import "path"
-import "path/filepath"
-import "strings"
-import "github.com/fatih/color"
-import "github.com/pivotal-golang/archiver/extractor"
-import "github.com/howtowhale/dvm/dvm-helper/checksum"
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/fatih/color"
+)
 
 func exportEnvironmentVariable(name string) string {
 	value := os.Getenv(name)
@@ -26,112 +24,12 @@ func exportEnvironmentVariable(name string) string {
 	return fmt.Sprintf("export %s=\"%s\"\n", name, value)
 }
 
-func pathExists(path string) bool {
-	_, err := os.Stat(path)
-	return err == nil
-}
-
 func ensureParentDirectoryExists(filePath string) {
 	dir := filepath.Dir(filePath)
 
 	err := os.MkdirAll(dir, 0777)
 	if err != nil {
 		die("Unable to create directory %s.", err, retCodeRuntimeError, dir)
-	}
-}
-
-func downloadFile(url string, destPath string) {
-	ensureParentDirectoryExists(destPath)
-
-	destFile, err := os.Create(destPath)
-	if err != nil {
-		die("Unable to create to %s.", err, retCodeRuntimeError, destPath)
-	}
-	defer destFile.Close()
-	os.Chmod(destPath, 0755)
-
-	writeDebug("Downloading %s", url)
-
-	response, err := http.Get(url)
-	if err != nil {
-		die("Unable to download %s.", err, retCodeRuntimeError, url)
-	}
-
-	if response.StatusCode != 200 {
-		die("Unable to download %s. (Status %d)", nil, retCodeRuntimeError, url, response.StatusCode)
-	}
-	defer response.Body.Close()
-
-	_, err = io.Copy(destFile, response.Body)
-	if err != nil {
-		die("Unable to write to %s.", err, retCodeRuntimeError, destPath)
-	}
-}
-
-func downloadFileWithChecksum(url string, destPath string) {
-	fileName := filepath.Base(destPath)
-	tmpPath := filepath.Join(dvmDir, ".tmp", fileName)
-	downloadFile(url, tmpPath)
-
-	checksumURL := url + ".sha256"
-	checksumPath := filepath.Join(dvmDir, ".tmp", (fileName + ".sh256"))
-	downloadFile(checksumURL, checksumPath)
-
-	checksum.CompareChecksum(tmpPath, checksumPath)
-	isValid, err := checksum.CompareChecksum(tmpPath, checksumPath)
-	if err != nil {
-		die("Unable to calculate checksum of %s.", err, retCodeRuntimeError, tmpPath)
-	}
-	if !isValid {
-		die("The checksum of %s failed to match %s.", nil, retCodeRuntimeError, tmpPath, checksumPath)
-	}
-
-	// Copy to final location, if different
-	if destPath != tmpPath {
-		ensureParentDirectoryExists(destPath)
-		err = os.Rename(tmpPath, destPath)
-		if err != nil {
-			die("Unable to copy %s to %s.", err, retCodeRuntimeError, tmpPath, destPath)
-		}
-	}
-
-	// Cleanup temp files
-	if err = os.Remove(checksumPath); err != nil {
-		writeWarning("Unable to remove temporary file: %s.", checksumPath)
-	}
-}
-
-func downloadArchivedFile(url string, archivedFile string, destPath string) {
-	archiveName := path.Base(url)
-	tmpPath := filepath.Join(dvmDir, ".tmp", archiveName)
-	downloadFile(url, tmpPath)
-	extractArchive(tmpPath, archiveName, archivedFile, destPath)
-}
-
-func downloadArchivedFileWithChecksum(url string, archivedFile string, destPath string) {
-	archiveName := path.Base(url)
-	tmpPath := filepath.Join(dvmDir, ".tmp", archiveName)
-	downloadFileWithChecksum(url, tmpPath)
-	extractArchive(tmpPath, archiveName, archivedFile, destPath)
-}
-func extractArchive(tmpPath string, archiveName string, archivedFile string, destPath string) {
-	// Extract the archive
-	archivePath := filepath.Join(dvmDir, ".tmp", strings.TrimSuffix(archiveName, filepath.Ext(archiveName)))
-	extractor := extractor.NewDetectable()
-	extractor.Extract(tmpPath, archivePath)
-	// Copy the archived file to the final destination
-	archivedFilePath := filepath.Join(archivePath, archivedFile)
-	ensureParentDirectoryExists(destPath)
-	err := os.Rename(archivedFilePath, destPath)
-	if err != nil {
-		die("Unable to copy %s to %s.", err, retCodeRuntimeError, archivedFilePath, destPath)
-	}
-	// Cleanup temp files
-	if err = os.Remove(tmpPath); err != nil {
-		writeWarning("Unable to remove temporary file: %s\n%s", tmpPath, err)
-	}
-	if err = os.RemoveAll(archivePath); err != nil {
-		writeWarning("Unable to remove temporary directory: %s\n%s", archivePath, err)
 	}
 }
 


### PR DESCRIPTION
Docker publishes releases that don't have a prerelease suffix (e.g. `-rc`) to the test location (look in https://download.docker.com/mac/static/test/x86_64/ and you'll see `17.10.0-ce`). Then some time later, when the version is ready for a final release, they publish a new release with the same version to the stable location.

Since we can't tell where to find a version based on its value anymore, first try downloading from stable, then if that fails, check if there's a test release available.

Related to #170.