### PR TITLE
Use dvm tmp for docker downloads

### DIFF
--- a/dvm-helper/dockerversion/dockerversion.go
+++ b/dvm-helper/dockerversion/dockerversion.go
@@ -2,13 +2,13 @@ package dockerversion
 
 import (
 	"fmt"
-	"log"
 	"net/http"
 	"path/filepath"
 	"sort"
 	"strings"
 
 	"github.com/Masterminds/semver"
+	"github.com/howtowhale/dvm/dvm-helper/internal/config"
 	"github.com/howtowhale/dvm/dvm-helper/internal/downloader"
 	"github.com/pkg/errors"
 )
@@ -102,26 +102,26 @@ func (version Version) buildDownloadURL(mirror string, forcePrerelease bool) (ur
 // version - the desired version.
 // mirrorURL - optional alternate download location.
 // binaryPath - full path to where the Docker client binary should be saved.
-func (version Version) Download(mirrorURL string, dvmDir string, binaryPath string, l *log.Logger) error {
-	err := version.download(false, mirrorURL, dvmDir, binaryPath, l)
+func (version Version) Download(opts config.DvmOptions, binaryPath string) error {
+	err := version.download(false, opts, binaryPath)
 	if err != nil && !version.IsPrerelease() && version.shouldBeInDockerStore() {
 		// Docker initially publishes non-rc version versions to the test location
 		// and then later republishes to the stable location
 		// Retry stable versions against test to find "unstable" stable versions. :-)
-		l.Printf("Could not find a stable release for %s, checking for a test release\n", version)
-		retryErr := version.download(true, mirrorURL, dvmDir, binaryPath, l)
+		opts.Logger.Printf("Could not find a stable release for %s, checking for a test release\n", version)
+		retryErr := version.download(true, opts, binaryPath)
 		return errors.Wrapf(retryErr, "Attempted to fallback to downloading from the prerelease location after downloading from the stable location failed: %s", err.Error())
 	}
 	return err
 }
 
-func (version Version) download(forcePrerelease bool, mirrorURL string, dvmDir string, binaryPath string, l *log.Logger) error {
-	url, archived, checksumed, err := version.buildDownloadURL(mirrorURL, forcePrerelease)
+func (version Version) download(forcePrerelease bool, opts config.DvmOptions, binaryPath string) error {
+	url, archived, checksumed, err := version.buildDownloadURL(opts.MirrorURL, forcePrerelease)
 	if err != nil {
 		return errors.Wrapf(err, "Unable to determine the download URL for %s", version)
 	}
 
-	l.Printf("Checking if %s can be found at %s", version, url)
+	opts.Logger.Printf("Checking if %s can be found at %s", version, url)
 	head, err := http.Head(url)
 	if err != nil {
 		return errors.Wrapf(err, "Unable to determine if %s is a valid version", version)
@@ -130,7 +130,7 @@ func (version Version) download(forcePrerelease bool, mirrorURL string, dvmDir s
 		return errors.Errorf("Version %s not found (%v) - try `dvm ls-remote` to browse available versions", version, head.StatusCode)
 	}
 
-	d := downloader.New(dvmDir, l)
+	d := downloader.New(opts)
 	binaryName := filepath.Base(binaryPath)
 
 	if archived {

--- a/dvm-helper/dockerversion/dockerversion_test.go
+++ b/dvm-helper/dockerversion/dockerversion_test.go
@@ -7,8 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"log"
-
+	"github.com/howtowhale/dvm/dvm-helper/internal/config"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 )
@@ -212,11 +211,11 @@ func TestVersion_BuildDownloadURL(t *testing.T) {
 func TestVersion_DownloadEdgeRelease(t *testing.T) {
 	version := Parse("edge")
 	tempDir, _ := ioutil.TempDir("", "dvmtest")
-	dvmDir := filepath.Join(tempDir, ".dvm")
-	destPath := filepath.Join(dvmDir, "docker")
+	opts := config.NewDvmOptions()
+	opts.DvmDir = filepath.Join(tempDir, ".dvm")
+	destPath := filepath.Join(opts.DvmDir, "docker")
 
-	l := log.New(ioutil.Discard, "", log.LstdFlags)
-	err := version.Download("", dvmDir, destPath, l)
+	err := version.Download(opts, destPath)
 	if err != nil {
 		t.Fatalf("%#v", err)
 	}

--- a/dvm-helper/dockerversion/dockerversion_test.go
+++ b/dvm-helper/dockerversion/dockerversion_test.go
@@ -212,10 +212,11 @@ func TestVersion_BuildDownloadURL(t *testing.T) {
 func TestVersion_DownloadEdgeRelease(t *testing.T) {
 	version := Parse("edge")
 	tempDir, _ := ioutil.TempDir("", "dvmtest")
-	destPath := filepath.Join(tempDir, "docker")
+	dvmDir := filepath.Join(tempDir, ".dvm")
+	destPath := filepath.Join(dvmDir, "docker")
 
 	l := log.New(ioutil.Discard, "", log.LstdFlags)
-	err := version.Download("", destPath, l)
+	err := version.Download("", dvmDir, destPath, l)
 	if err != nil {
 		t.Fatalf("%#v", err)
 	}

--- a/dvm-helper/dvm-helper.go
+++ b/dvm-helper/dvm-helper.go
@@ -429,7 +429,7 @@ func install(version dockerversion.Version) {
 
 func downloadRelease(version dockerversion.Version) {
 	destPath := filepath.Join(getVersionDir(version), getBinaryName())
-	err := version.Download(mirrorURL, destPath, getDebugLogger())
+	err := version.Download(mirrorURL, dvmDir, destPath, getDebugLogger())
 	if err != nil {
 		die("", err, retCodeRuntimeError)
 	}

--- a/dvm-helper/dvm-helper.go
+++ b/dvm-helper/dvm-helper.go
@@ -18,6 +18,7 @@ import (
 	"github.com/fatih/color"
 	"github.com/google/go-github/github"
 	"github.com/howtowhale/dvm/dvm-helper/dockerversion"
+	"github.com/howtowhale/dvm/dvm-helper/internal/config"
 	"github.com/howtowhale/dvm/dvm-helper/url"
 	"github.com/pkg/errors"
 	"github.com/ryanuber/go-glob"
@@ -25,20 +26,16 @@ import (
 )
 
 // These are global command line variables
-var shell string
-var dvmDir string
-var mirrorURL string
-var githubUrlOverride string
-var debug bool
-var silent bool
+var opts config.DvmOptions
+
+// This is a nasty global state flag that we flip. Bad Carolyn.
 var useAfterInstall bool
-var token string
-var includePrereleases bool
 
 // These are set during the build
 var dvmVersion string
 var dvmCommit string
 var upgradeDisabled string // Allow package managers like homebrew to disable in-place upgrades
+var githubUrlOverride string
 
 const (
 	retCodeInvalidArgument  = 127
@@ -274,20 +271,20 @@ func makeCliApp() *cli.App {
 func setGlobalVars(c *cli.Context) {
 	useAfterInstall = true
 
-	debug = c.GlobalBool("debug")
-	token = c.GlobalString("github-token")
-	shell = c.GlobalString("shell")
+	opts.Debug = c.GlobalBool("debug")
+	opts.Token = c.GlobalString("github-token")
+	opts.Shell = c.GlobalString("shell")
 	validateShellFlag()
 
-	silent = c.GlobalBool("silent")
-	mirrorURL = c.String("mirror-url")
-	includePrereleases = c.Bool("pre")
+	opts.Silent = c.GlobalBool("silent")
+	opts.MirrorURL = c.String("mirror-url")
+	opts.IncludePrereleases = c.Bool("pre")
 
-	dvmDir = c.GlobalString("dvm-dir")
-	if dvmDir == "" {
-		dvmDir = filepath.Join(getUserHomeDir(), ".dvm")
+	opts.DvmDir = c.GlobalString("dvm-dir")
+	if opts.DvmDir == "" {
+		opts.DvmDir = filepath.Join(getUserHomeDir(), ".dvm")
 	}
-	writeDebug("The dvm home directory is: %s", dvmDir)
+	writeDebug("The dvm home directory is: %s", opts.DvmDir)
 }
 
 func detect() {
@@ -429,7 +426,7 @@ func install(version dockerversion.Version) {
 
 func downloadRelease(version dockerversion.Version) {
 	destPath := filepath.Join(getVersionDir(version), getBinaryName())
-	err := version.Download(mirrorURL, dvmDir, destPath, getDebugLogger())
+	err := version.Download(opts.MirrorURL, opts.DvmDir, destPath, getDebugLogger())
 	if err != nil {
 		die("", err, retCodeRuntimeError)
 	}
@@ -438,7 +435,7 @@ func downloadRelease(version dockerversion.Version) {
 }
 
 func getDebugLogger() *log.Logger {
-	if debug {
+	if opts.Debug {
 		return log.New(color.Output, "", log.LstdFlags)
 	}
 	return log.New(ioutil.Discard, "", log.LstdFlags)
@@ -561,7 +558,7 @@ func getAliases() map[string]string {
 }
 
 func getAliasPath(alias string) string {
-	return filepath.Join(dvmDir, "alias", alias)
+	return filepath.Join(opts.DvmDir, "alias", alias)
 }
 
 func getBinaryName() string {
@@ -587,14 +584,14 @@ func writeEnvironmentVariableScript(name string) {
 
 func buildDvmOutputScriptPath() string {
 	var fileExtension string
-	if shell == "powershell" {
+	if opts.Shell == "powershell" {
 		fileExtension = "ps1"
-	} else if shell == "cmd" {
+	} else if opts.Shell == "cmd" {
 		fileExtension = "cmd"
 	} else { // default to bash
 		fileExtension = "sh"
 	}
-	return filepath.Join(dvmDir, ".tmp", ("dvm-output." + fileExtension))
+	return filepath.Join(opts.DvmDir, ".tmp", "dvm-output."+fileExtension)
 }
 
 func removePreviousDockerVersionFromPath() {
@@ -712,7 +709,7 @@ func getDockerVersion(dockerPath string, includeBuild bool) (dockerversion.Versi
 }
 
 func listRemote(prefix string) {
-	versions := getAvailableVersions(prefix, includePrereleases)
+	versions := getAvailableVersions(prefix, opts.IncludePrereleases)
 	for _, version := range versions {
 		writeInfo(version.String())
 	}
@@ -768,7 +765,7 @@ func getAvailableVersions(pattern string, includePrereleases bool) []dockerversi
 	}
 
 	writeDebug("Retrieving Docker releases")
-	stableVersions, err := dockerversion.ListVersions(mirrorURL, dockerversion.Stable)
+	stableVersions, err := dockerversion.ListVersions(opts.MirrorURL, dockerversion.Stable)
 	if err != nil {
 		die("", err, retCodeRuntimeError)
 	}
@@ -780,7 +777,7 @@ func getAvailableVersions(pattern string, includePrereleases bool) []dockerversi
 
 	if includePrereleases {
 		writeDebug("Retrieving Docker pre-releases")
-		prereleaseVersions, err := dockerversion.ListVersions(mirrorURL, dockerversion.Test)
+		prereleaseVersions, err := dockerversion.ListVersions(opts.MirrorURL, dockerversion.Test)
 		if err != nil {
 			die("", err, retCodeRuntimeError)
 		}
@@ -867,7 +864,7 @@ func isUpgradeAvailable() (bool, string) {
 }
 
 func getVersionsDir() string {
-	return filepath.Join(dvmDir, "bin", "docker")
+	return filepath.Join(opts.DvmDir, "bin", "docker")
 }
 
 func getVersionDir(version dockerversion.Version) string {
@@ -883,8 +880,8 @@ func getDockerVersionVar() string {
 }
 
 func buildGithubClient() *github.Client {
-	if token != "" {
-		tokenSource := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
+	if opts.Token != "" {
+		tokenSource := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: opts.Token})
 		httpClient := oauth2.NewClient(oauth2.NoContext, tokenSource)
 		return github.NewClient(httpClient)
 	}

--- a/dvm-helper/dvm-helper.nix.go
+++ b/dvm-helper/dvm-helper.nix.go
@@ -12,7 +12,7 @@ import (
 const binaryFileExt string = ""
 
 func upgradeSelf(version string) {
-	d := downloader.New(getDebugLogger())
+	d := downloader.New(dvmDir, getDebugLogger())
 
 	binaryURL := buildDvmReleaseURL(version, dvmOS, dvmArch, "dvm-helper")
 	binaryPath := filepath.Join(dvmDir, "dvm-helper", "dvm-helper")

--- a/dvm-helper/dvm-helper.nix.go
+++ b/dvm-helper/dvm-helper.nix.go
@@ -12,7 +12,7 @@ import (
 const binaryFileExt string = ""
 
 func upgradeSelf(version string) {
-	d := downloader.New(opts.DvmDir, getDebugLogger())
+	d := downloader.New(opts)
 
 	binaryURL := buildDvmReleaseURL(version, dvmOS, dvmArch, "dvm-helper")
 	binaryPath := filepath.Join(opts.DvmDir, "dvm-helper", "dvm-helper")

--- a/dvm-helper/dvm-helper.nix.go
+++ b/dvm-helper/dvm-helper.nix.go
@@ -12,17 +12,17 @@ import (
 const binaryFileExt string = ""
 
 func upgradeSelf(version string) {
-	d := downloader.New(dvmDir, getDebugLogger())
+	d := downloader.New(opts.DvmDir, getDebugLogger())
 
 	binaryURL := buildDvmReleaseURL(version, dvmOS, dvmArch, "dvm-helper")
-	binaryPath := filepath.Join(dvmDir, "dvm-helper", "dvm-helper")
+	binaryPath := filepath.Join(opts.DvmDir, "dvm-helper", "dvm-helper")
 	err := d.DownloadFileWithChecksum(binaryURL, binaryPath)
 	if err != nil {
 		die("", err, retCodeRuntimeError)
 	}
 
 	scriptURL := buildDvmReleaseURL(version, "dvm.sh")
-	scriptPath := filepath.Join(dvmDir, "dvm.sh")
+	scriptPath := filepath.Join(opts.DvmDir, "dvm.sh")
 	err = d.DownloadFile(scriptURL, scriptPath)
 	if err != nil {
 		die("", err, retCodeRuntimeError)

--- a/dvm-helper/dvm-helper.windows.go
+++ b/dvm-helper/dvm-helper.windows.go
@@ -15,7 +15,7 @@ const dvmOS string = "Windows"
 const binaryFileExt string = ".exe"
 
 func upgradeSelf(version string) {
-	d := downloader.New(opts.DvmDir, getDebugLogger())
+	d := downloader.New(opts)
 
 	binaryURL := buildDvmReleaseURL(version, dvmOS, dvmArch, "dvm-helper.exe")
 	binaryPath := filepath.Join(opts.DvmDir, ".tmp", "dvm-helper.exe")

--- a/dvm-helper/dvm-helper.windows.go
+++ b/dvm-helper/dvm-helper.windows.go
@@ -15,7 +15,7 @@ const dvmOS string = "Windows"
 const binaryFileExt string = ".exe"
 
 func upgradeSelf(version string) {
-	d := downloader.New(getDebugLogger())
+	d := downloader.New(dvmDir, getDebugLogger())
 
 	binaryURL := buildDvmReleaseURL(version, dvmOS, dvmArch, "dvm-helper.exe")
 	binaryPath := filepath.Join(dvmDir, ".tmp", "dvm-helper.exe")

--- a/dvm-helper/dvm-helper.windows.go
+++ b/dvm-helper/dvm-helper.windows.go
@@ -15,24 +15,24 @@ const dvmOS string = "Windows"
 const binaryFileExt string = ".exe"
 
 func upgradeSelf(version string) {
-	d := downloader.New(dvmDir, getDebugLogger())
+	d := downloader.New(opts.DvmDir, getDebugLogger())
 
 	binaryURL := buildDvmReleaseURL(version, dvmOS, dvmArch, "dvm-helper.exe")
-	binaryPath := filepath.Join(dvmDir, ".tmp", "dvm-helper.exe")
+	binaryPath := filepath.Join(opts.DvmDir, ".tmp", "dvm-helper.exe")
 	err := d.DownloadFileWithChecksum(binaryURL, binaryPath)
 	if err != nil {
 		die("", err, retCodeRuntimeError)
 	}
 
 	psScriptURL := buildDvmReleaseURL(version, "dvm.ps1")
-	psScriptPath := filepath.Join(dvmDir, "dvm.ps1")
+	psScriptPath := filepath.Join(opts.DvmDir, "dvm.ps1")
 	err = d.DownloadFile(psScriptURL, psScriptPath)
 	if err != nil {
 		die("", err, retCodeRuntimeError)
 	}
 
 	cmdScriptURL := buildDvmReleaseURL(version, "dvm.cmd")
-	cmdScriptPath := filepath.Join(dvmDir, "dvm.cmd")
+	cmdScriptPath := filepath.Join(opts.DvmDir, "dvm.cmd")
 	err = d.DownloadFile(cmdScriptURL, cmdScriptPath)
 	if err != nil {
 		die("", err, retCodeRuntimeError)
@@ -43,11 +43,11 @@ func upgradeSelf(version string) {
 
 func writeUpgradeScript() {
 	scriptPath := buildDvmOutputScriptPath()
-	tmpBinaryPath := filepath.Join(dvmDir, ".tmp", "dvm-helper.exe")
-	binaryPath := filepath.Join(dvmDir, "dvm-helper", "dvm-helper.exe")
+	tmpBinaryPath := filepath.Join(opts.DvmDir, ".tmp", "dvm-helper.exe")
+	binaryPath := filepath.Join(opts.DvmDir, "dvm-helper", "dvm-helper.exe")
 
 	var contents string
-	if shell == "powershell" {
+	if opts.Shell == "powershell" {
 		contents = fmt.Sprintf("cp -force '%s' '%s'", tmpBinaryPath, binaryPath)
 	} else { // cmd
 		contents = fmt.Sprintf("cp /Y '%s' '%s'", tmpBinaryPath, binaryPath)
@@ -63,7 +63,7 @@ func getCleanPathRegex() string {
 }
 
 func validateShellFlag() {
-	if shell != "powershell" && shell != "cmd" {
+	if opts.Shell != "powershell" && opts.Shell != "cmd" {
 		die("The --shell flag or SHELL environment variable must be set when running on Windows. Available values are powershell and cmd.", nil, retCodeInvalidArgument)
 	}
 }

--- a/dvm-helper/internal/config/config.go
+++ b/dvm-helper/internal/config/config.go
@@ -1,5 +1,10 @@
 package config
 
+import (
+	"io/ioutil"
+	"log"
+)
+
 type DvmOptions struct {
 	DvmDir             string
 	MirrorURL          string
@@ -8,4 +13,11 @@ type DvmOptions struct {
 	Debug              bool
 	Silent             bool
 	IncludePrereleases bool
+	Logger             *log.Logger
+}
+
+func NewDvmOptions() DvmOptions {
+	return DvmOptions{
+		Logger: log.New(ioutil.Discard, "", log.LstdFlags),
+	}
 }

--- a/dvm-helper/internal/config/config.go
+++ b/dvm-helper/internal/config/config.go
@@ -1,0 +1,11 @@
+package config
+
+type DvmOptions struct {
+	DvmDir             string
+	MirrorURL          string
+	Token              string
+	Shell              string
+	Debug              bool
+	Silent             bool
+	IncludePrereleases bool
+}

--- a/dvm-helper/internal/downloader/downloader.go
+++ b/dvm-helper/internal/downloader/downloader.go
@@ -2,7 +2,6 @@ package downloader
 
 import (
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -11,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/howtowhale/dvm/dvm-helper/checksum"
+	"github.com/howtowhale/dvm/dvm-helper/internal/config"
 	"github.com/pivotal-golang/archiver/extractor"
 	"github.com/pkg/errors"
 )
@@ -23,14 +23,11 @@ type Client struct {
 
 // New creates a downloader client.
 // l - optional logger for debug output
-func New(dvmDir string, l *log.Logger) Client {
-	if l == nil {
-		l = log.New(ioutil.Discard, "", log.LstdFlags)
-	}
-	tmpDir := filepath.Join(dvmDir, ".tmp")
-
+func New(opts config.DvmOptions) Client {
 	return Client{
-		log: l, tmp: tmpDir}
+		log: opts.Logger,
+		tmp: filepath.Join(opts.DvmDir, ".tmp"),
+	}
 }
 
 func (d Client) ensureParentDirectoryExists(path string) error {

--- a/dvm-helper/internal/downloader/downloader.go
+++ b/dvm-helper/internal/downloader/downloader.go
@@ -23,11 +23,11 @@ type Client struct {
 
 // New creates a downloader client.
 // l - optional logger for debug output
-func New(l *log.Logger) Client {
+func New(dvmDir string, l *log.Logger) Client {
 	if l == nil {
 		l = log.New(ioutil.Discard, "", log.LstdFlags)
 	}
-	tmpDir, _ := ioutil.TempDir("", "dvm")
+	tmpDir := filepath.Join(dvmDir, ".tmp")
 
 	return Client{
 		log: l, tmp: tmpDir}
@@ -52,7 +52,7 @@ func (d Client) DownloadFile(url string, destPath string) error {
 	defer destFile.Close()
 	os.Chmod(destPath, 0755)
 
-	d.log.Printf("Downloading %s\n", url)
+	d.log.Printf("Downloading %s to %s\n", url, destPath)
 
 	response, err := http.Get(url)
 	if err != nil {

--- a/dvm-helper/util.go
+++ b/dvm-helper/util.go
@@ -12,11 +12,11 @@ import (
 func exportEnvironmentVariable(name string) string {
 	value := os.Getenv(name)
 
-	if shell == "powershell" {
+	if opts.Shell == "powershell" {
 		return fmt.Sprintf("$env:%s=\"%s\"\r\n", name, value)
 	}
 
-	if shell == "cmd" {
+	if opts.Shell == "cmd" {
 		return fmt.Sprintf("%s=%s\r\n", name, value)
 	}
 
@@ -53,7 +53,7 @@ func writeFile(path string, contents string) {
 }
 
 func writeDebug(format string, a ...interface{}) {
-	if !debug {
+	if !opts.Debug {
 		return
 	}
 
@@ -61,7 +61,7 @@ func writeDebug(format string, a ...interface{}) {
 }
 
 func writeInfo(format string, a ...interface{}) {
-	if silent {
+	if opts.Silent {
 		return
 	}
 
@@ -69,7 +69,7 @@ func writeInfo(format string, a ...interface{}) {
 }
 
 func writeWarning(format string, a ...interface{}) {
-	if silent {
+	if opts.Silent {
 		return
 	}
 


### PR DESCRIPTION
Download docker binary to `~/.dvm/.tmp` instead of `/tmp/dvm-*` so that when we copy it into the dvm home directory afterwards we can always use a rename safely. This avoids this dreaded cross partition move error `invalid cross-device link`.

Fixes #188 