### PR TITLE
Tweak CI Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,9 @@
 language: go
 go:
-- 1.7.x
-- 1.8.x
-- 1.9.x
-- tip
+- 1.11.x
 go_import_path: github.com/howtowhale/dvm
 git:
   depth: 9999999
-sudo: false # Run in a container
 script:
 - make test
 - make cross-build

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ SHELL := /bin/bash
 
 COMMIT = $(shell git rev-parse --verify --short HEAD)
 VERSION = $(shell git describe --tags --dirty='-dev' 2> /dev/null)
+BREW_VERSION = $(shell git describe --tags --abbrev=0 2> /dev/null)
 PERMALINK = $(shell if [[ $(VERSION) =~ [^-]*-([^.]+).* ]]; then echo $${BASH_REMATCH[1]}; else echo "latest"; fi)
 
 GITHUB_ORG = howtowhale
@@ -19,6 +20,9 @@ GOFILES = dvm-helper/*.go
 GOFILES_NOVENDOR = $(shell go list ./... | grep -v /vendor/)
 
 default: local
+
+homebrew:
+	brew bump-formula-pr --strict --url=https://github.com/howtowhale/dvm/archive/$(BREW_VERSION).tar.gz dvm
 
 validate:
 	go fmt $(GOFILES_NOVENDOR)


### PR DESCRIPTION
* Use go 1.11 only for faster builds.
    We are currently building against go 1.7 - 1.10 but I'm not sure at this point that's terribly helpful? I'd rather just build against the current go version (especially as go fmt/vet and other tools differ in what they enforce across versions).
* Add a homebrew target. I keep forgetting how to publish the latest version of dvm to homebrew. 😊 This has been sitting uncommitted in my local repo for a year?
* Travis has deprecated containerized builds. So I'm removing that config option as it's misleading.