### PR TITLE
Fix build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ validate:
 	-go list ./... | grep -v /vendor/ | xargs -L1 golint --set_exit_status
 
 test: local
-	go test $(GOFILES_NOVENDOR)
+	go test -v $(GOFILES_NOVENDOR)
 	eval "$( ./dvm-helper --bash-completion )"
 	./dvm-helper/dvm-helper --version
 

--- a/dvm-helper/dockerversion/dockerversion_test.go
+++ b/dvm-helper/dockerversion/dockerversion_test.go
@@ -132,25 +132,31 @@ func TestVersion_BuildDownloadURL(t *testing.T) {
 		},
 
 		// original download location, without compression, prerelease
+		/* test.docker.com has been removed by docker
 		Parse("1.10.0-rc1"): {
 			wantURL:      fmt.Sprintf("https://test.docker.com/builds/%s/%s/docker-1.10.0-rc1", dockerOS, dockerArch),
 			wantArchived: false,
 			wantChecksum: true,
 		},
+		*/
 
 		// compressed binaries
+		/* test.docker.com has been removed by docker
 		Parse("1.11.0-rc1"): {
 			wantURL:      fmt.Sprintf("https://test.docker.com/builds/%s/%s/docker-1.11.0-rc1.tgz", dockerOS, dockerArch),
 			wantArchived: true,
 			wantChecksum: true,
 		},
+		*/
 
 		// original version scheme, prerelease binaries
+		/* test.docker.com has been removed by docker
 		Parse("1.13.0-rc1"): {
 			wantURL:      fmt.Sprintf("https://test.docker.com/builds/%s/%s/docker-1.13.0-rc1.tgz", dockerOS, dockerArch),
 			wantArchived: true,
 			wantChecksum: true,
 		},
+		*/
 
 		// yearly notation, original download location, release location
 		Parse("17.03.0-ce"): {

--- a/dvm-helper/dvm-helper.go
+++ b/dvm-helper/dvm-helper.go
@@ -814,7 +814,7 @@ func listLegacyDockerVersions() ([]dockerversion.Version, error) {
 		}
 		allReleases = append(allReleases, releases...)
 		if response.StatusCode != 200 {
-			return nil, errors.Errorf("Unable to retrieve list of Docker releases from GitHub (Status %s).", response.StatusCode)
+			return nil, errors.Errorf("Unable to retrieve list of Docker releases from GitHub (Status %v).", response.StatusCode)
 		}
 		if response.NextPage == 0 {
 			break

--- a/dvm-helper/dvm-helper_test.go
+++ b/dvm-helper/dvm-helper_test.go
@@ -155,11 +155,11 @@ func TestInstallPrereleases(t *testing.T) {
 	color.Output = outputCapture
 
 	dvm := makeCliApp()
-	dvm.Run([]string{"dvm-helper", "--debug", "install", "1.12.5-rc1"})
+	dvm.Run([]string{"dvm-helper", "--debug", "install", "18.06.1-ce"})
 
 	output := outputCapture.String()
 	assert.NotEmpty(t, output, "Should have captured stdout")
-	assert.Contains(t, output, "Now using Docker 1.12.5-rc1", "Should have installed a prerelease version")
+	assert.Contains(t, output, "Now using Docker 18.06.1-ce", "Should have installed a prerelease version")
 }
 
 // install a version from the test location that is missing the -rc suffix


### PR DESCRIPTION
* test.docker.com has been removed by Docker and replaced with a download script. I don't know where you can even file those files anymore. ¯\_(ツ)_/¯. I'm keeping the tests commented out in case anyone wants to go spleunking. But mostly to vent some spleen. 😀 
* Fix a vet error that is making the build fail
* Updated one of the tests to use a version of docker that is still available